### PR TITLE
Change Japanese encoding to utf-8 without BOM.

### DIFF
--- a/Research_and_Development/Publication/paper_2005_ja.txt
+++ b/Research_and_Development/Publication/paper_2005_ja.txt
@@ -1,7 +1,7 @@
-// Title: ˜_•¶ (2005”N)
+// Title: è«–æ–‡ (2005å¹´)
 #contents
 
-**‘ÛŠw‰ï
+**å›½éš›å­¦ä¼š
 +Noriaki ANDO, Takashi SUEHIRO, Kosei KITAGAKI, Tetsuo KOTOKU, Woo-Keun YOON, "RT-Component Object Model in RT-Middleware- Distributed Component Middleware for RT (Robot Technology) -", 2005 IEEE International Symposium on Computational Intelligence in Robotics and Automation (CIRA2005), p.We-B2-5, 2005.06, Espoo, Finland
 +Noriaki ANDO, Takashi SUEHIRO, Kosei KITAGAKI, Tetsuo KOTOKU, Woo-Keun Yoon, "Composite Component Framework for RT-Middleware (Robot Technology Middleware)", 2005 IEEE/ASME International Conference on Advanced Intelligent Mechatronics (AIM2005), pp.1330-1335, 2005.07, Monterey, California, U.S.A.
 +Noriaki ANDO, Takashi SUEHIRO, Kosei KITAGAKI, Tetsuo KOTOKU, Woo-Keun Yoon, "RT-Middleware: Distributed Component Middleware for RT (Robot Technology)", 2005 IEEE/RSJ International Conference on Intelligent Robots and Systems (IROS2005), pp.3555-3560, 2005.08, Edmonton, Canada
@@ -10,26 +10,26 @@
 +Olivier LEMAIRE, Tetsuo KOTOKU, Takashi SUEHIRO, Noriaki ANDO, Kohtaro OHBA, Makoto MIZUKAWA, "An approach to the standardization of the Robotic Technology", The 2nd International Conference on Ubiquitous Robots and Ambient Intelligence, pp.120-123, 2005.11, Daejeon, Korea
 +Hideaki OGAWA, Noriaki ANDO, Satoshi ONODERA, "SmallConnection: Designing of Tangible Communication Media over Networks", 13th ACM International Conference on Multimedia 2005, pp.1073-1074, 2005.11, Singapore &ref(ACMMM2005_Ogawa.pdf,[PDF]);
 
-**‘“àŠw‰ï
-+ˆÀ“¡ Œcº, ––œA ®Žm, –kŠ_ ‚¬, _“¿ “O—Y, ›š —Sª, "ƒŠƒAƒ‹ƒ^ƒCƒ€§Œä‚Ì‚½‚ß‚Ì•¡‡RTƒRƒ“ƒ|[ƒlƒ“ƒgƒtƒŒ[ƒ€ƒ[ƒN‚ÌŽÀ‘• --RTƒ~ƒhƒ‹ƒEƒFƒA‚ÌŠî–{‹@”\‚ÉŠÖ‚·‚éŒ¤‹†ŠJ”­(‚»‚Ì11)--", ‘æ10‰ñ ƒƒ{ƒeƒBƒNƒXƒVƒ“ƒ|ƒWƒA, pp.1-6, 2005.03, ” ªA_“Þì &ref(RoboticsSymposia2005_Ando.pdf,[PDF]);
-+›š —Sª, ––œA ®Žm, –kŠ_ ‚¬, ‰¹“c O, ˆÀ“¡ Œcº, âV“¡ Žj—Ï, ’†‘º W, "‰“Šu‘€ì‚ð—˜—p‚µ‚½ƒ^ƒXƒNƒXƒLƒ‹ì¬Žè–@", ‘æ10‰ñ ƒƒ{ƒeƒBƒNƒXƒVƒ“ƒ|ƒWƒA, pp.493-500, 2005.03, ” ªA_“Þì &ref(RoboticsSymposia2005_Yoon.pdf,[PDF]);
-+–kŠ_ ‚¬, ––œA ®Žm, _“¿ “O—Y, ›š —Sª, ˆÀ“¡ Œcº, •½ˆä ¬‹», ’J] ˜a—Y, "‚q‚sƒ~ƒhƒ‹ƒEƒFƒA‚Ì“WŠJ", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2003 (SI2003), pp.23-24, 2003.12, “Œ‹ž‘åŠw &ref(ROBOMEC2005_Kitagaki_2P1N065.pdf,[PDF]);
-+ˆÀ“¡ Œcº, ––œA ®Žm, –kŠ_ ‚¬, _“¿ “O—Y, ›š —Sª, "RT ƒRƒ“ƒ|[ƒlƒ“ƒg‚É‚æ‚éƒVƒXƒeƒ€\’z–@ -RT ƒ~ƒhƒ‹ƒEƒFƒA‚ÌŠî–{‹@”\‚ÉŠÖ‚·‚éŒ¤‹†ŠJ”­(‚»‚Ì14)-", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2005, p.2A1-N-072, 2005.06, _ŒË &ref(ROBOMEC2005_Ando_RT_2A1N072.pdf,[PDF]);
-+ˆÀ“¡ Œcº, ¬ìG–¾, "RT ƒ~ƒhƒ‹ƒEƒGƒA‚ÌƒƒfƒBƒAƒA[ƒg‚Ö‚Ì‰ž—p -ƒp[ƒ\ƒiƒ‹‚ÈƒRƒ~ƒ…ƒjƒP[ƒVƒ‡ƒ“ƒƒfƒBƒA: SmallConnection-", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2005, p.1P2-S-038, 2005.06, _ŒË &ref(ROBOMEC2005_Ando_SC_1P2S038.pdf,[PDF]);
-+–kŠ_ ‚¬, ì“c N•½, ‘åŒ´ Œ«ˆê, ‹{è Šw, ‘åê Œõ‘¾˜Y, ––œA ®Žm, ˆÀ“¡ Œcº, "RT ƒRƒ“ƒ|[ƒlƒ“ƒg‚ð—p‚¢‚½ƒVƒXƒeƒ€‚ÌÝŒv‚ÉŒü‚¯‚Ä|Ž–—áF ‘Ð®—ƒVƒXƒeƒ€|", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2005, p.2P1-N-065, 2005.06, _ŒË &ref(ROBOMEC2005_Kitagaki_2P1N065.pdf,[PDF]);
-+_“¿ “O—Y, ––œA ®Žm, ˆÀ“¡ Œcº, ›š —Sª, –kŠ_ ‚¬, •½ˆä ¬‹», ’J] ˜a—Y, …ì ^, "RTƒ~ƒhƒ‹ƒEƒFƒA•W€‰»Šˆ“®‚Ö‚Ì—U‚¢", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2005, p.2P1-N-066, 2005.06, _ŒË &ref(ROBOMEC2005_Kotoku_2P1N066.pdf,[PDF]);
-+ˆÀ“¡ Œcº, VÈ ŽÀ•ÛŽq, “s“‡ —Ç‹v, ‹´–{@G‹I, "RTƒ~ƒhƒ‹ƒEƒGƒA‚É‚æ‚é’m”\‰»‹óŠÔ‚ÌƒVƒXƒeƒ€ƒfƒUƒCƒ“", ‘æ23‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.2B22, 2005.09, _“Þì &ref(RSJ2005_Ando_2B22.pdf,[PDF]);
-+ˆÀ“¡ Œcº, –kŠ_ ‚¬, Lemaire, Olivier, _“¿ “O—Y, ––œA ®Žm, "RTƒRƒ“ƒ|[ƒlƒ“ƒgEƒT[ƒrƒXƒtƒŒ[ƒ€ƒ[ƒN -RT ƒ~ƒhƒ‹ƒEƒFƒA‚ÌŠî–{‹@”\‚ÉŠÖ‚·‚éŒ¤‹†ŠJ”­(‚»‚Ì15)- ", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2005 (SI2005), p.3C1-2, 2005.12, ŒF–{ &ref(SI2005_Ando_3C1_2.pdf,[PDF]);
-+––œA ®Žm, –kŠ_ ‚¬, _“¿ “O—Y, ›š —Sª, ˆÀ“¡ Œcº, "ƒƒ{ƒbƒg—pƒ~ƒhƒ‹ƒEƒFƒA", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2005 (SI2005), p.2D1-3, 2005.12, ŒF–{ &ref(SI2005_Suehiro_2D1_3.pdf,[PDF]);
-+ˆîŠ_ Šw, —é–Ø ‹ª, ‘åŒ´ Œ«ˆê, ’Jì –¯¶, ˆÀ“¡ Œcº, ‘åê Œõ‘¾˜Y, •½ˆä ¬‹», …ì ^, ’J] ˜a—Y, "RTƒRƒ“ƒ|[ƒlƒ“ƒg‰»‚³‚ê‚½‘gž‚ÝCPU‚É‚æ‚éˆÚ“®‘äŽÔ§Œä", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2005 (SI2005), p.3C3-1, 2005.12, ŒF–{ &ref(SI2005_Inagaki_3C3_1.pdf,[PDF]);
-+ˆÀ“¡ Œcº, —é–Ø ‹ª, ‘åŒ´ Œ«ˆê, ‘åê Œõ‘¾˜Y, ’J] ˜a—Y, "‘gž‹@Ší‚Ì‚½‚ß‚ÌŒy—ÊRTƒRƒ“ƒ|[ƒlƒ“ƒgFRTComponent-Lite", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2005 (SI2005), p.3C2-2, 2005.12, ŒF–{ &ref(SI2005_Suzuki_3C2_2.pdf,[PDF]);
-+’Jì –¯¶, —Fš  L•Û, ‘åŒ´ Œ«ˆê, ˆÀ“¡ Œcº, ‹à •òª, ‘åê Œõ‘¾˜Y, •½ˆä ¬‹», "‘½—l‚ÈƒT[ƒrƒX‚Ì‚½‚ß‚Ì‹@”\‰Â•ÏŒ^RTƒVƒXƒeƒ€", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2005 (SI2005), p.3C2-2, 2005.12, ŒF–{ &ref(SI2005_Tanikawa_3C1_3.pdf,[PDF]);
-+ˆÀ“¡ Œcº, VÈ ŽÀ•ÛŽq, “s“‡ —Ç‹v, ‹´–{@G‹I, "RTƒ~ƒhƒ‹ƒEƒGƒA‚É‚æ‚é’m”\‰»‹óŠÔ‚ÌƒVƒXƒeƒ€ƒfƒUƒCƒ“", ‘æ23‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.2B22, 2005.09, _“Þì &ref(RSJ2005_Ando_2B22.pdf,[PDF]);
+**å›½å†…å­¦ä¼š
++å®‰è—¤ æ…¶æ˜­, æœ«å»£ å°šå£«, åŒ—åž£ é«˜æˆ, ç¥žå¾³ å¾¹é›„, å°¹ ç¥æ ¹, "ãƒªã‚¢ãƒ«ã‚¿ã‚¤ãƒ åˆ¶å¾¡ã®ãŸã‚ã®è¤‡åˆRTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆãƒ•ãƒ¬ãƒ¼ãƒ ãƒ¯ãƒ¼ã‚¯ã®å®Ÿè£… --RTãƒŸãƒ‰ãƒ«ã‚¦ã‚§ã‚¢ã®åŸºæœ¬æ©Ÿèƒ½ã«é–¢ã™ã‚‹ç ”ç©¶é–‹ç™º(ãã®11)--", ç¬¬10å›ž ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ã‚·ãƒ³ãƒã‚¸ã‚¢, pp.1-6, 2005.03, ç®±æ ¹ã€ç¥žå¥ˆå· &ref(RoboticsSymposia2005_Ando.pdf,[PDF]);
++å°¹ ç¥æ ¹, æœ«å»£ å°šå£«, åŒ—åž£ é«˜æˆ, éŸ³ç”° å¼˜, å®‰è—¤ æ…¶æ˜­, é½‹è—¤ å²å€«, ä¸­æ‘ æ™ƒ, "é éš”æ“ä½œã‚’åˆ©ç”¨ã—ãŸã‚¿ã‚¹ã‚¯ã‚¹ã‚­ãƒ«ä½œæˆæ‰‹æ³•", ç¬¬10å›ž ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ã‚·ãƒ³ãƒã‚¸ã‚¢, pp.493-500, 2005.03, ç®±æ ¹ã€ç¥žå¥ˆå· &ref(RoboticsSymposia2005_Yoon.pdf,[PDF]);
++åŒ—åž£ é«˜æˆ, æœ«å»£ å°šå£«, ç¥žå¾³ å¾¹é›„, å°¹ ç¥æ ¹, å®‰è—¤ æ…¶æ˜­, å¹³äº• æˆèˆˆ, è°·æ±Ÿ å’Œé›„, "ï¼²ï¼´ãƒŸãƒ‰ãƒ«ã‚¦ã‚§ã‚¢ã®å±•é–‹", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2003 (SI2003), pp.23-24, 2003.12, æ±äº¬å¤§å­¦ &ref(ROBOMEC2005_Kitagaki_2P1N065.pdf,[PDF]);
++å®‰è—¤ æ…¶æ˜­, æœ«å»£ å°šå£«, åŒ—åž£ é«˜æˆ, ç¥žå¾³ å¾¹é›„, å°¹ ç¥æ ¹, "RT ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã«ã‚ˆã‚‹ã‚·ã‚¹ãƒ†ãƒ æ§‹ç¯‰æ³• -RT ãƒŸãƒ‰ãƒ«ã‚¦ã‚§ã‚¢ã®åŸºæœ¬æ©Ÿèƒ½ã«é–¢ã™ã‚‹ç ”ç©¶é–‹ç™º(ãã®14)-", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2005, p.2A1-N-072, 2005.06, ç¥žæˆ¸ &ref(ROBOMEC2005_Ando_RT_2A1N072.pdf,[PDF]);
++å®‰è—¤ æ…¶æ˜­, å°å·ç§€æ˜Ž, "RT ãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢ã®ãƒ¡ãƒ‡ã‚£ã‚¢ã‚¢ãƒ¼ãƒˆã¸ã®å¿œç”¨ -ãƒ‘ãƒ¼ã‚½ãƒŠãƒ«ãªã‚³ãƒŸãƒ¥ãƒ‹ã‚±ãƒ¼ã‚·ãƒ§ãƒ³ãƒ¡ãƒ‡ã‚£ã‚¢: SmallConnection-", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2005, p.1P2-S-038, 2005.06, ç¥žæˆ¸ &ref(ROBOMEC2005_Ando_SC_1P2S038.pdf,[PDF]);
++åŒ—åž£ é«˜æˆ, ä½œç”° åº·å¹³, å¤§åŽŸ è³¢ä¸€, å®®å´Ž å­¦, å¤§å ´ å…‰å¤ªéƒŽ, æœ«å»£ å°šå£«, å®‰è—¤ æ…¶æ˜­, "RT ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã‚’ç”¨ã„ãŸã‚·ã‚¹ãƒ†ãƒ ã®è¨­è¨ˆã«å‘ã‘ã¦ï¼äº‹ä¾‹ï¼š æ›¸ç±æ•´ç†ã‚·ã‚¹ãƒ†ãƒ ï¼", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2005, p.2P1-N-065, 2005.06, ç¥žæˆ¸ &ref(ROBOMEC2005_Kitagaki_2P1N065.pdf,[PDF]);
++ç¥žå¾³ å¾¹é›„, æœ«å»£ å°šå£«, å®‰è—¤ æ…¶æ˜­, å°¹ ç¥æ ¹, åŒ—åž£ é«˜æˆ, å¹³äº• æˆèˆˆ, è°·æ±Ÿ å’Œé›„, æ°´å· çœŸ, "RTãƒŸãƒ‰ãƒ«ã‚¦ã‚§ã‚¢æ¨™æº–åŒ–æ´»å‹•ã¸ã®èª˜ã„", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2005, p.2P1-N-066, 2005.06, ç¥žæˆ¸ &ref(ROBOMEC2005_Kotoku_2P1N066.pdf,[PDF]);
++å®‰è—¤ æ…¶æ˜­, æ–°å¦» å®Ÿä¿å­, éƒ½å³¶ è‰¯ä¹…, æ©‹æœ¬ã€€ç§€ç´€, "RTãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢ã«ã‚ˆã‚‹çŸ¥èƒ½åŒ–ç©ºé–“ã®ã‚·ã‚¹ãƒ†ãƒ ãƒ‡ã‚¶ã‚¤ãƒ³", ç¬¬23å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.2B22, 2005.09, ç¥žå¥ˆå· &ref(RSJ2005_Ando_2B22.pdf,[PDF]);
++å®‰è—¤ æ…¶æ˜­, åŒ—åž£ é«˜æˆ, Lemaire, Olivier, ç¥žå¾³ å¾¹é›„, æœ«å»£ å°šå£«, "RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆãƒ»ã‚µãƒ¼ãƒ“ã‚¹ãƒ•ãƒ¬ãƒ¼ãƒ ãƒ¯ãƒ¼ã‚¯ -RT ãƒŸãƒ‰ãƒ«ã‚¦ã‚§ã‚¢ã®åŸºæœ¬æ©Ÿèƒ½ã«é–¢ã™ã‚‹ç ”ç©¶é–‹ç™º(ãã®15)- ", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2005 (SI2005), p.3C1-2, 2005.12, ç†Šæœ¬ &ref(SI2005_Ando_3C1_2.pdf,[PDF]);
++æœ«å»£ å°šå£«, åŒ—åž£ é«˜æˆ, ç¥žå¾³ å¾¹é›„, å°¹ ç¥æ ¹, å®‰è—¤ æ…¶æ˜­, "ãƒ­ãƒœãƒƒãƒˆç”¨ãƒŸãƒ‰ãƒ«ã‚¦ã‚§ã‚¢", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2005 (SI2005), p.2D1-3, 2005.12, ç†Šæœ¬ &ref(SI2005_Suehiro_2D1_3.pdf,[PDF]);
++ç¨²åž£ å­¦, éˆ´æœ¨ å–¬, å¤§åŽŸ è³¢ä¸€, è°·å· æ°‘ç”Ÿ, å®‰è—¤ æ…¶æ˜­, å¤§å ´ å…‰å¤ªéƒŽ, å¹³äº• æˆèˆˆ, æ°´å· çœŸ, è°·æ±Ÿ å’Œé›„, "RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆåŒ–ã•ã‚ŒãŸçµ„è¾¼ã¿CPUã«ã‚ˆã‚‹ç§»å‹•å°è»Šåˆ¶å¾¡", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2005 (SI2005), p.3C3-1, 2005.12, ç†Šæœ¬ &ref(SI2005_Inagaki_3C3_1.pdf,[PDF]);
++å®‰è—¤ æ…¶æ˜­, éˆ´æœ¨ å–¬, å¤§åŽŸ è³¢ä¸€, å¤§å ´ å…‰å¤ªéƒŽ, è°·æ±Ÿ å’Œé›„, "çµ„è¾¼æ©Ÿå™¨ã®ãŸã‚ã®è»½é‡RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆï¼šRTComponent-Lite", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2005 (SI2005), p.3C2-2, 2005.12, ç†Šæœ¬ &ref(SI2005_Suzuki_3C2_2.pdf,[PDF]);
++è°·å· æ°‘ç”Ÿ, å‹åœ‹ ä¼¸ä¿, å¤§åŽŸ è³¢ä¸€, å®‰è—¤ æ…¶æ˜­, é‡‘ å¥‰æ ¹, å¤§å ´ å…‰å¤ªéƒŽ, å¹³äº• æˆèˆˆ, "å¤šæ§˜ãªã‚µãƒ¼ãƒ“ã‚¹ã®ãŸã‚ã®æ©Ÿèƒ½å¯å¤‰åž‹RTã‚·ã‚¹ãƒ†ãƒ ", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2005 (SI2005), p.3C2-2, 2005.12, ç†Šæœ¬ &ref(SI2005_Tanikawa_3C1_3.pdf,[PDF]);
++å®‰è—¤ æ…¶æ˜­, æ–°å¦» å®Ÿä¿å­, éƒ½å³¶ è‰¯ä¹…, æ©‹æœ¬ã€€ç§€ç´€, "RTãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢ã«ã‚ˆã‚‹çŸ¥èƒ½åŒ–ç©ºé–“ã®ã‚·ã‚¹ãƒ†ãƒ ãƒ‡ã‚¶ã‚¤ãƒ³", ç¬¬23å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.2B22, 2005.09, ç¥žå¥ˆå· &ref(RSJ2005_Ando_2B22.pdf,[PDF]);
 
-**˜_•¶ŒöŠJ‹K’è‚É‚Â‚¢‚Ä
-–{ƒy[ƒW‚Å‚ÍAŠeŠw‰ï‚Ì˜_•¶ŒöŠJ‹K’è‚É]‚Á‚Ä‰Â”\‚ÈŒÀ‚è˜_•¶Œ´e‚ÌŒöŠJ‚ðs‚Á‚Ä‚¨‚è‚Ü‚·B
+**è«–æ–‡å…¬é–‹è¦å®šã«ã¤ã„ã¦
+æœ¬ãƒšãƒ¼ã‚¸ã§ã¯ã€å„å­¦ä¼šã®è«–æ–‡å…¬é–‹è¦å®šã«å¾“ã£ã¦å¯èƒ½ãªé™ã‚Šè«–æ–‡åŽŸç¨¿ã®å…¬é–‹ã‚’è¡Œã£ã¦ãŠã‚Šã¾ã™ã€‚
 
--[[ƒƒ{ƒbƒgŠw‰ï:http://www.rsj.or.jp/JRSJ/kaitei_20060215.html]]
---–{l‚ªŽ©g‚¨‚æ‚ÑŠ‘®‹@ŠÖ‚ÌWebƒy[ƒW‚ÅŒöŠJ‚·‚éŒÀ‚è‹–‘ø‚³‚ê‚éB
--[[“ú–{‹@ŠBŠw‰ï:http://www.jsme.or.jp/publish/yoko/yokob_t.htm]]
---–{l‚ªŽ©g‚¨‚æ‚ÑŠ‘®‹@ŠÖ‚ÌWebƒy[ƒW‚ÅŒöŠJ‚·‚éŒÀ‚è‹–‘ø‚³‚ê‚éB
+-[[ãƒ­ãƒœãƒƒãƒˆå­¦ä¼š:http://www.rsj.or.jp/JRSJ/kaitei_20060215.html]]
+--æœ¬äººãŒè‡ªèº«ãŠã‚ˆã³æ‰€å±žæ©Ÿé–¢ã®Webãƒšãƒ¼ã‚¸ã§å…¬é–‹ã™ã‚‹é™ã‚Šè¨±è«¾ã•ã‚Œã‚‹ã€‚
+-[[æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š:http://www.jsme.or.jp/publish/yoko/yokob_t.htm]]
+--æœ¬äººãŒè‡ªèº«ãŠã‚ˆã³æ‰€å±žæ©Ÿé–¢ã®Webãƒšãƒ¼ã‚¸ã§å…¬é–‹ã™ã‚‹é™ã‚Šè¨±è«¾ã•ã‚Œã‚‹ã€‚

--- a/Research_and_Development/Publication/paper_2006_ja.txt
+++ b/Research_and_Development/Publication/paper_2006_ja.txt
@@ -1,38 +1,38 @@
-// Title: ˜_•¶ (2006”N)
+// Title: è«–æ–‡ (2006å¹´)
 #contents
 
-**‘ÛŠw‰ï
+**å›½éš›å­¦ä¼š
 +Noriaki ANDO, Takashi Suehiro, Kosei Kitagaki, Tetsuo Kotoku, "RT(Robot Technology)-Component and its Standardization- Towards Component Based Networked Robot Systems Development -", SICE-ICASE International Joint Conference 2006 (SICE-ICCAS 2006), pp.2633-2638, 2006.10, Busan, Korea &ref(SICE2006_Ando_FA12-5.pdf, [PDF]);
 +Kenichi Ohara, Takashi Suzuki, Noriaki ANDO, Bong Keun Kim, Kohtaro Ohba, Kazuo Tanie, "Distributed Control of Robot Functions using RT Middleware", SICE-ICASE International Joint Conference 2006 (SICE-ICCAS 2006), pp.2629-2632, 2006.10, Busan, Korea &ref(SICE2006_Ohara_FA12-4.pdf, [PDF]);
 +Yutaka TSUCHIYA, Makoto MIZUKAWA, Takashi SUEHIRO, Noriaki ANDO, Hiroyuki NAKAMOTO, Akihiro IKEZOE, "Development of Light-Weight RT-Component (LwRTC) on Embedded Processor-Application to Crawler Control Subsystem in the Physical Agent System-", SICE-ICASE International Joint Conference 2006 (SICE-ICCAS 2006), pp.2618-2622, 2006.10, Busan, Korea &ref(SICE2006_Tsuchiya_FA12-2.pdf, [PDF]);
 +Yoshihisa TOSHIMA, Qinhe WANG, Noriaki ANDO, Hideki Hashimoto, "Occlusion Avoidance of Information Display System in Intelligent Space", SICE-ICASE International Joint Conference 2006 (SICE-ICCAS 2006), pp.2663-2667, 2006.10, Busan, Korea &ref(SICE2006_Toshima_FA13-2.pdf, [PDF]);
 
-**‘“àŠw‰ï
-+ˆÀ–FŽŸ, ˆäã,’‡‹g,“¡ˆä,ŒÜ\—’,¬‹Ê, ˆÀ“¡ Œcº, _“¿ “O—Y, ––œA ®Žm, •½–ì ‘, "FEASIBILITY OF DATA ACQUISITION MIDDLEWARE BASED ON ROBOT TECHNOLOGY ", Int. Conf. on Computing in High Energy and Nuclear Physics, 2006.02, ƒCƒ“ƒh@ƒ€ƒ“ƒoƒCŽs
-+ˆÀ“¡ Œcº, ƒ‹ƒƒA ƒIƒŠƒrƒG, ––œA ®Žm, _“¿ “O—Y, –kŠ_ ‚¬, "RTƒ~ƒhƒ‹ƒEƒGƒA‚ÌPIM,PSM‚¨‚æ‚ÑŽÀ‘• |RTƒ~ƒhƒ‹ƒEƒGƒA‚Ì•W€‰»‚ÉŒü‚¯‚Ä|", ‘æ11‰ñ ƒƒ{ƒeƒBƒNƒXƒVƒ“ƒ|ƒWƒA, pp.432-437, 2006.03, ²‰êŒ§, Šð–ì
-+“s“‡ —Ç‹v, ‰¤ e˜a, ˆÀ“¡ Œcº, —é–Ø ‹ª, ‹´–{ G‹I, "‹óŠÔ’m”\‰»‚Ì‚½‚ß‚Ìƒlƒbƒgƒ[ƒNÚ‘±Œ^î•ñ’ñŽ¦‘•’u -RTƒRƒ“ƒ|[ƒlƒ“ƒg‚ð—p‚¢‚½ƒAƒNƒeƒBƒuƒvƒƒWƒFƒNƒ^‚ÌŠJ”­-", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2006, p.2P1-E19, 2006.05, ‘ˆî“c‘åŠw, “Œ‹ž &ref(ROBOMEC06_Toshima_2P1_E19.pdf, [PDF]);
-+ˆîŠ_ Šw, —é–Ø ‹ª, ‘åŒ´ Œ«ˆê, ˆÀ“¡ Œcº, ’Jì –¯¶, ‘åê Œõ‘¾˜Y, •½ˆä ¬‹», …ì áÁ, "•ªŽU”z’u‚³‚ê‚½ƒZƒ“ƒT‚ð—p‚¢‚½ˆÚ“®‘äŽÔ§Œä -ƒ†ƒrƒLƒ^ƒXEƒƒ{ƒbƒg‚É‚¨‚¯‚é•¡”ƒZƒ“ƒTƒRƒ“ƒ|[ƒlƒ“ƒg‚Ì‘I‘ð—˜—p-", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2006, p.1P1-C37, 2006.05, ‘ˆî“c‘åŠw, “Œ‹ž &ref(ROBOMEC06_Inagaki_1P1_C37.pdf, [PDF]);
-+Œ´ —C•ã, š ˆä N°, ˆÀ“¡ Œcº, "RTƒ~ƒhƒ‹ƒEƒFƒA‚ð—˜—p‚µ‚½‰“ŠuˆÚ“®ƒƒ{ƒbƒgƒVƒXƒeƒ€‚Ì\’z", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2006, p.1P1-C36, 2006.05, ‘ˆî“c‘åŠw, “Œ‹ž &ref(ROBOMEC06_Hara_1P1_C36.pdf, [PDF]);
-+—é–Ø ‹ª, ˆÀ“¡ Œcº, ˆîŠ_ Šw, ‘åŒ´ Œ«ˆê, ‘åê Œõ‘¾˜Y, ’J] ˜a—Y, "‘½—l‚È‘gž‚Ý‹@Ší‚Å“®ì‚·‚é RTComponet-Lite ‚ÌŠJ”­", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2006, p.1P1-C35, 2006.05, ‘ˆî“c‘åŠw, “Œ‹ž &ref(ROBOMEC06_Suzuki_1P1_C35.pdf, [PDF]);
-+ˆÀ“¡ Œcº, _“¿ “O—Y, ƒ‹ƒƒA ƒIƒŠƒrƒG, –kŠ_ ‚¬, ––œA ®Žm, "SDO (Super Distributed Object) ‚ÉŠî‚Ã‚¢‚½ RT-Component ƒIƒuƒWƒFƒNƒgƒ‚ƒfƒ‹", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2006, p.1P1-C23, 2006.05, ‘ˆî“c‘åŠw, “Œ‹ž &ref(ROBOMEC06_Ando_1P1_C23.pdf, [PDF]);
-+“y‰® —T, …ì ^, ˆÀ“¡ ‹gL, ––œA ®Žm, ˆÀ“¡ Œcº, ’†–{ Œ[”V, ’r“Y –¾G, "RTƒ~ƒhƒ‹ƒEƒFƒA‚ð—p‚¢‚½CANƒ‚ƒWƒ…[ƒ‹\¬Œ^ƒƒ{ƒbƒg‚Ì\’z", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2006, p.1P1-C31, 2006.05, ‘ˆî“c‘åŠw, “Œ‹ž &ref(ROBOMEC06_Tsuchiya_1P1_C31.pdf, [PDF]);
-+Œ´ —C•ã, ‚‹´ VŒá, š ˆä N°, ˆÀ“¡ Œcº, "ƒlƒbƒgƒ[ƒN‹y‚Ñƒ‚ƒWƒ…[ƒ‹\¬‚É‚æ‚é‰“ŠuˆÚ“®ƒƒ{ƒbƒg‚ÌƒVƒXƒeƒ€ŒŸ“¢", ‘æ24‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.1D22, 2006.09, ‰ªŽR‘åŠw, ‰ªŽRŒ§ &ref(RSJ2006_Hara_1D22.pdf, [PDF]);
-+”ä—¯ì”Ž‹v, ‹àL•¶’j, ’†‰ªTˆê˜Y, ––œA®Žm, _“¿“O—Y, ˆÀ“¡Œcº, ’†‘ºm•FCŽRªŽ, âV“¡Œ³CìŠp—Sˆê˜Y, "•ªŽUƒRƒ“ƒ|[ƒlƒ“ƒgŒ^ƒƒ{ƒbƒgƒVƒ~ƒ…ƒŒ[ƒ^", ‘æ24‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.2N21, 2006.09, ‰ªŽR‘åŠw, ‰ªŽRŒ§ &ref(RSJ2006_Hirukawa_2N21.pdf, [PDF]);
-+_“¿ “O—Y, ˆÀ“¡ Œcº, ––œA ®Žm, "RTƒ~ƒhƒ‹ƒEƒGƒA‚ð—p‚¢‚½•ªŽUƒRƒ“ƒ|[ƒlƒ“ƒgƒtƒŒ[ƒ€ƒ[ƒN \RTƒ~ƒhƒ‹ƒEƒFƒA‚Ì‹@”\Šg’£‚ÌŒŸ“¢\", ‘æ24‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.2N22, 2006.09, ‰ªŽR‘åŠw, ‰ªŽRŒ§ &ref(RSJ2006_Kotoku_2N22.pdf, [PDF]);
-+“s“‡ —Ç‹v, VÈŽÀ•ÛŽq, ˆÀ“¡ Œcº, ‹´–{@G‹I, "RT Component ‚ð—p‚¢‚½î•ñ’ñŽ¦ƒVƒXƒeƒ€‚Ì\¬", ‘æ24‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.3D16, 2006.09, ‰ªŽR‘åŠw, ‰ªŽRŒ§ &ref(RSJ2006_Toshima_3D16.pdf, [PDF]);
-+“y‰® —T, …ì ^, ––œA ®Žm, ˆÀ“¡ Œcº, ’†–{ Œ[”V, ’r“Y –¾G, "RT ƒ~ƒhƒ‹ƒEƒFƒA‚¨‚æ‚Ñ‘gž‚Ýƒvƒ‰ƒbƒgƒtƒH[ƒ€‚ð—p‚¢‚½ˆÚ“®Œ^ƒƒ{ƒbƒg—p§ŒäƒVƒXƒeƒ€‚ÌŠJ”­", ‘æ24‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.3D14, 2006.09, ‰ªŽR‘åŠw, ‰ªŽRŒ§ &ref(RSJ2006_Tsuchiya_3D14.pdf, [PDF]);
-+—é–Ø ‹ª, ‘åŒ´ Œ«ˆê, ˆÀ“¡ Œcº, ‘åê Œõ‘¾˜Y, ’J] ˜a—Y, "‚q‚sƒ~ƒhƒ‹ƒEƒGƒA‚ð“K—p‚µ‚½ƒƒ{ƒbƒg‹@”\—v‘f‚Ì•ªŽU§Œä", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2006 (SI2006), p.1B3-6, 2006.12, ŽD–y, –kŠC“¹ &ref(SI2006_Suzuki_1B3_6.pdf, [PDF]);
-+ˆÀ“¡ Œcº, "‹óŠÔ’mƒvƒ‰ƒbƒgƒtƒH[ƒ€‚Æ‚µ‚Ä‚ÌRTƒ~ƒhƒ‹ƒEƒGƒA", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2006 (SI2006), p.1B4-4, 2006.12, ŽD–y, –kŠC“¹ &ref(SI2006_Ando_1B4_4.pdf, [PDF]);
-+“s“‡ —Ç‹v, ˆÀ“¡ Œcº, ‹´–{@G‹I, "ƒAƒNƒeƒBƒuƒvƒƒWƒFƒNƒ^‚ð—p‚¢‚½î•ñ’ñŽ¦ƒVƒXƒeƒ€‚É‚¨‚¯‚é“Š‰e˜c‚Ý•â³", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2006 (SI2006), p.2I1-1, 2006.12, ŽD–y, –kŠC“¹ &ref(SI2006_Toshima_2I1_1.pdf, [PDF]);
-+ŽO‰Y rG, …ì ^, ’r“Y –¾G, ˆÀ“¡ Œcº, ˆÀ“¡ ‹gL, “y‰® —T, "‘gžƒvƒƒZƒbƒT{Windows CE‚Ö‚ÌRTƒ~ƒhƒ‹ƒEƒFƒA‚ÌŽÀ‘•", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2006 (SI2006), p.3B1-3, 2006.12, ŽD–y, –kŠC“¹ &ref(SI2006_Miura_3B1_3.pdf, [PDF]);
-+“y‰® —T, …ì ^, ––œA ®Žm, ˆÀ“¡ Œcº, ’†–{ Œ[”V, ’r“Y –¾G, "‚q‚sƒ~ƒhƒ‹ƒEƒFƒA‚ð—p‚¢‚½‚b‚`‚m‘Î‰ž‘gžƒRƒ“ƒgƒ[ƒ‰‚ÌŠJ”­(‚q‚s‚b|‚b‚`‚mƒVƒXƒeƒ€) ", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2006 (SI2006), p.3B1-4, 2006.12, ŽD–y, –kŠC“¹ &ref(SI2006_Tsuchiya_3B1_4.pdf, [PDF]);
-+ˆÀ“¡ Œcº, _“¿ “O—Y, ˆÀ –FŽŸ, ‹v•Û“c ‹M–ç, ‘åì –Ò, •½–ì ‘, "RTƒRƒ“ƒ|[ƒlƒ“ƒg‚ÌInPort/OutPortƒf[ƒ^“]‘—•û–@‚Ì‘½—l‰»-Raw TCP/IP Socket ‚É‚æ‚éƒf[ƒ^“]‘— -", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2006 (SI2006), p.3B2-1, 2006.12, ŽD–y, –kŠC“¹ &ref(SI2006_Ando_3B2_1.pdf, [PDF]);
-+––œA ®Žm, ‚‹´ —TM, –å“à ³˜a , –kŠ_ ‚¬, Šì‘½ L”V, ‰¹“c O, ˆÀ“¡ Œcº, _“¿ “O—Y, "OpenRTM‚Ì‚½‚ß‚Ì‚RŽŸŒ³ƒXƒeƒŒƒIŽ‹Šo”FŽ¯ƒRƒ“ƒ|[ƒlƒ“ƒg‚ÌŽÀ‘•", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2006 (SI2006), p.3B2-4, 2006.12, ŽD–y, –kŠC“¹ &ref(SI2006_Takahashi_3B2_4.pdf, [PDF]);
+**å›½å†…å­¦ä¼š
++å®‰èŠ³æ¬¡, äº•ä¸Š,ä»²å‰,è—¤äº•,äº”ååµ,å°çŽ‰, å®‰è—¤ æ…¶æ˜­, ç¥žå¾³ å¾¹é›„, æœ«å»£ å°šå£«, å¹³é‡Ž è¡, "FEASIBILITY OF DATA ACQUISITION MIDDLEWARE BASED ON ROBOT TECHNOLOGY ", Int. Conf. on Computing in High Energy and Nuclear Physics, 2006.02, ã‚¤ãƒ³ãƒ‰ã€€ãƒ ãƒ³ãƒã‚¤å¸‚
++å®‰è—¤ æ…¶æ˜­, ãƒ«ãƒ¡ã‚¢ ã‚ªãƒªãƒ“ã‚¨, æœ«å»£ å°šå£«, ç¥žå¾³ å¾¹é›„, åŒ—åž£ é«˜æˆ, "RTãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢ã®PIM,PSMãŠã‚ˆã³å®Ÿè£… ï¼RTãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢ã®æ¨™æº–åŒ–ã«å‘ã‘ã¦ï¼", ç¬¬11å›ž ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ã‚·ãƒ³ãƒã‚¸ã‚¢, pp.432-437, 2006.03, ä½è³€çœŒ, å¬‰é‡Ž
++éƒ½å³¶ è‰¯ä¹…, çŽ‹ è¦ªå’Œ, å®‰è—¤ æ…¶æ˜­, éˆ´æœ¨ å–¬, æ©‹æœ¬ ç§€ç´€, "ç©ºé–“çŸ¥èƒ½åŒ–ã®ãŸã‚ã®ãƒãƒƒãƒˆãƒ¯ãƒ¼ã‚¯æŽ¥ç¶šåž‹æƒ…å ±æç¤ºè£…ç½® -RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã‚’ç”¨ã„ãŸã‚¢ã‚¯ãƒ†ã‚£ãƒ–ãƒ—ãƒ­ã‚¸ã‚§ã‚¯ã‚¿ã®é–‹ç™º-", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2006, p.2P1-E19, 2006.05, æ—©ç¨²ç”°å¤§å­¦, æ±äº¬ &ref(ROBOMEC06_Toshima_2P1_E19.pdf, [PDF]);
++ç¨²åž£ å­¦, éˆ´æœ¨ å–¬, å¤§åŽŸ è³¢ä¸€, å®‰è—¤ æ…¶æ˜­, è°·å· æ°‘ç”Ÿ, å¤§å ´ å…‰å¤ªéƒŽ, å¹³äº• æˆèˆˆ, æ°´å· çœž, "åˆ†æ•£é…ç½®ã•ã‚ŒãŸã‚»ãƒ³ã‚µã‚’ç”¨ã„ãŸç§»å‹•å°è»Šåˆ¶å¾¡ -ãƒ¦ãƒ“ã‚­ã‚¿ã‚¹ãƒ»ãƒ­ãƒœãƒƒãƒˆã«ãŠã‘ã‚‹è¤‡æ•°ã‚»ãƒ³ã‚µã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã®é¸æŠžåˆ©ç”¨-", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2006, p.1P1-C37, 2006.05, æ—©ç¨²ç”°å¤§å­¦, æ±äº¬ &ref(ROBOMEC06_Inagaki_1P1_C37.pdf, [PDF]);
++åŽŸ ä½‘è¼”, åœ‹äº• åº·æ™´, å®‰è—¤ æ…¶æ˜­, "RTãƒŸãƒ‰ãƒ«ã‚¦ã‚§ã‚¢ã‚’åˆ©ç”¨ã—ãŸé éš”ç§»å‹•ãƒ­ãƒœãƒƒãƒˆã‚·ã‚¹ãƒ†ãƒ ã®æ§‹ç¯‰", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2006, p.1P1-C36, 2006.05, æ—©ç¨²ç”°å¤§å­¦, æ±äº¬ &ref(ROBOMEC06_Hara_1P1_C36.pdf, [PDF]);
++éˆ´æœ¨ å–¬, å®‰è—¤ æ…¶æ˜­, ç¨²åž£ å­¦, å¤§åŽŸ è³¢ä¸€, å¤§å ´ å…‰å¤ªéƒŽ, è°·æ±Ÿ å’Œé›„, "å¤šæ§˜ãªçµ„è¾¼ã¿æ©Ÿå™¨ã§å‹•ä½œã™ã‚‹ RTComponet-Lite ã®é–‹ç™º", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2006, p.1P1-C35, 2006.05, æ—©ç¨²ç”°å¤§å­¦, æ±äº¬ &ref(ROBOMEC06_Suzuki_1P1_C35.pdf, [PDF]);
++å®‰è—¤ æ…¶æ˜­, ç¥žå¾³ å¾¹é›„, ãƒ«ãƒ¡ã‚¢ ã‚ªãƒªãƒ“ã‚¨, åŒ—åž£ é«˜æˆ, æœ«å»£ å°šå£«, "SDO (Super Distributed Object) ã«åŸºã¥ã„ãŸ RT-Component ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆãƒ¢ãƒ‡ãƒ«", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2006, p.1P1-C23, 2006.05, æ—©ç¨²ç”°å¤§å­¦, æ±äº¬ &ref(ROBOMEC06_Ando_1P1_C23.pdf, [PDF]);
++åœŸå±‹ è£•, æ°´å· çœŸ, å®‰è—¤ å‰ä¼¸, æœ«å»£ å°šå£«, å®‰è—¤ æ…¶æ˜­, ä¸­æœ¬ å•“ä¹‹, æ± æ·» æ˜Žå®, "RTãƒŸãƒ‰ãƒ«ã‚¦ã‚§ã‚¢ã‚’ç”¨ã„ãŸCANãƒ¢ã‚¸ãƒ¥ãƒ¼ãƒ«æ§‹æˆåž‹ãƒ­ãƒœãƒƒãƒˆã®æ§‹ç¯‰", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2006, p.1P1-C31, 2006.05, æ—©ç¨²ç”°å¤§å­¦, æ±äº¬ &ref(ROBOMEC06_Tsuchiya_1P1_C31.pdf, [PDF]);
++åŽŸ ä½‘è¼”, é«˜æ©‹ æ–°å¾, åœ‹äº• åº·æ™´, å®‰è—¤ æ…¶æ˜­, "ãƒãƒƒãƒˆãƒ¯ãƒ¼ã‚¯åŠã³ãƒ¢ã‚¸ãƒ¥ãƒ¼ãƒ«æ§‹æˆã«ã‚ˆã‚‹é éš”ç§»å‹•ãƒ­ãƒœãƒƒãƒˆã®ã‚·ã‚¹ãƒ†ãƒ æ¤œè¨Ž", ç¬¬24å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.1D22, 2006.09, å²¡å±±å¤§å­¦, å²¡å±±çœŒ &ref(RSJ2006_Hara_1D22.pdf, [PDF]);
++æ¯”ç•™å·åšä¹…, é‡‘åºƒæ–‡ç”·, ä¸­å²¡æ…Žä¸€éƒŽ, æœ«å»£å°šå£«, ç¥žå¾³å¾¹é›„, å®‰è—¤æ…¶æ˜­, ä¸­æ‘ä»å½¦ï¼Œå±±æ ¹å…‹, é½‹è—¤å…ƒï¼Œå·è§’ç¥ä¸€éƒŽ, "åˆ†æ•£ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆåž‹ãƒ­ãƒœãƒƒãƒˆã‚·ãƒŸãƒ¥ãƒ¬ãƒ¼ã‚¿", ç¬¬24å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.2N21, 2006.09, å²¡å±±å¤§å­¦, å²¡å±±çœŒ &ref(RSJ2006_Hirukawa_2N21.pdf, [PDF]);
++ç¥žå¾³ å¾¹é›„, å®‰è—¤ æ…¶æ˜­, æœ«å»£ å°šå£«, "RTãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢ã‚’ç”¨ã„ãŸåˆ†æ•£ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆãƒ•ãƒ¬ãƒ¼ãƒ ãƒ¯ãƒ¼ã‚¯ â€•RTãƒŸãƒ‰ãƒ«ã‚¦ã‚§ã‚¢ã®æ©Ÿèƒ½æ‹¡å¼µã®æ¤œè¨Žâ€•", ç¬¬24å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.2N22, 2006.09, å²¡å±±å¤§å­¦, å²¡å±±çœŒ &ref(RSJ2006_Kotoku_2N22.pdf, [PDF]);
++éƒ½å³¶ è‰¯ä¹…, æ–°å¦»å®Ÿä¿å­, å®‰è—¤ æ…¶æ˜­, æ©‹æœ¬ã€€ç§€ç´€, "RT Component ã‚’ç”¨ã„ãŸæƒ…å ±æç¤ºã‚·ã‚¹ãƒ†ãƒ ã®æ§‹æˆ", ç¬¬24å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.3D16, 2006.09, å²¡å±±å¤§å­¦, å²¡å±±çœŒ &ref(RSJ2006_Toshima_3D16.pdf, [PDF]);
++åœŸå±‹ è£•, æ°´å· çœŸ, æœ«å»£ å°šå£«, å®‰è—¤ æ…¶æ˜­, ä¸­æœ¬ å•“ä¹‹, æ± æ·» æ˜Žå®, "RT ãƒŸãƒ‰ãƒ«ã‚¦ã‚§ã‚¢ãŠã‚ˆã³çµ„è¾¼ã¿ãƒ—ãƒ©ãƒƒãƒˆãƒ•ã‚©ãƒ¼ãƒ ã‚’ç”¨ã„ãŸç§»å‹•åž‹ãƒ­ãƒœãƒƒãƒˆç”¨åˆ¶å¾¡ã‚·ã‚¹ãƒ†ãƒ ã®é–‹ç™º", ç¬¬24å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.3D14, 2006.09, å²¡å±±å¤§å­¦, å²¡å±±çœŒ &ref(RSJ2006_Tsuchiya_3D14.pdf, [PDF]);
++éˆ´æœ¨ å–¬, å¤§åŽŸ è³¢ä¸€, å®‰è—¤ æ…¶æ˜­, å¤§å ´ å…‰å¤ªéƒŽ, è°·æ±Ÿ å’Œé›„, "ï¼²ï¼´ãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢ã‚’é©ç”¨ã—ãŸãƒ­ãƒœãƒƒãƒˆæ©Ÿèƒ½è¦ç´ ã®åˆ†æ•£åˆ¶å¾¡", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2006 (SI2006), p.1B3-6, 2006.12, æœ­å¹Œ, åŒ—æµ·é“ &ref(SI2006_Suzuki_1B3_6.pdf, [PDF]);
++å®‰è—¤ æ…¶æ˜­, "ç©ºé–“çŸ¥ãƒ—ãƒ©ãƒƒãƒˆãƒ•ã‚©ãƒ¼ãƒ ã¨ã—ã¦ã®RTãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2006 (SI2006), p.1B4-4, 2006.12, æœ­å¹Œ, åŒ—æµ·é“ &ref(SI2006_Ando_1B4_4.pdf, [PDF]);
++éƒ½å³¶ è‰¯ä¹…, å®‰è—¤ æ…¶æ˜­, æ©‹æœ¬ã€€ç§€ç´€, "ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ãƒ—ãƒ­ã‚¸ã‚§ã‚¯ã‚¿ã‚’ç”¨ã„ãŸæƒ…å ±æç¤ºã‚·ã‚¹ãƒ†ãƒ ã«ãŠã‘ã‚‹æŠ•å½±æ­ªã¿è£œæ­£", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2006 (SI2006), p.2I1-1, 2006.12, æœ­å¹Œ, åŒ—æµ·é“ &ref(SI2006_Toshima_2I1_1.pdf, [PDF]);
++ä¸‰æµ¦ ä¿Šå®, æ°´å· çœŸ, æ± æ·» æ˜Žå®, å®‰è—¤ æ…¶æ˜­, å®‰è—¤ å‰ä¼¸, åœŸå±‹ è£•, "çµ„è¾¼ãƒ—ãƒ­ã‚»ãƒƒã‚µï¼‹Windows CEã¸ã®RTãƒŸãƒ‰ãƒ«ã‚¦ã‚§ã‚¢ã®å®Ÿè£…", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2006 (SI2006), p.3B1-3, 2006.12, æœ­å¹Œ, åŒ—æµ·é“ &ref(SI2006_Miura_3B1_3.pdf, [PDF]);
++åœŸå±‹ è£•, æ°´å· çœŸ, æœ«å»£ å°šå£«, å®‰è—¤ æ…¶æ˜­, ä¸­æœ¬ å•“ä¹‹, æ± æ·» æ˜Žå®, "ï¼²ï¼´ãƒŸãƒ‰ãƒ«ã‚¦ã‚§ã‚¢ã‚’ç”¨ã„ãŸï¼£ï¼¡ï¼®å¯¾å¿œçµ„è¾¼ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ©ã®é–‹ç™º(ï¼²ï¼´ï¼£ï¼ï¼£ï¼¡ï¼®ã‚·ã‚¹ãƒ†ãƒ ) ", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2006 (SI2006), p.3B1-4, 2006.12, æœ­å¹Œ, åŒ—æµ·é“ &ref(SI2006_Tsuchiya_3B1_4.pdf, [PDF]);
++å®‰è—¤ æ…¶æ˜­, ç¥žå¾³ å¾¹é›„, å®‰ èŠ³æ¬¡, ä¹…ä¿ç”° è²´ä¹Ÿ, å¤§å· çŒ›, å¹³é‡Ž è¡, "RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã®InPort/OutPortãƒ‡ãƒ¼ã‚¿è»¢é€æ–¹æ³•ã®å¤šæ§˜åŒ–-Raw TCP/IP Socket ã«ã‚ˆã‚‹ãƒ‡ãƒ¼ã‚¿è»¢é€ -", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2006 (SI2006), p.3B2-1, 2006.12, æœ­å¹Œ, åŒ—æµ·é“ &ref(SI2006_Ando_3B2_1.pdf, [PDF]);
++æœ«å»£ å°šå£«, é«˜æ©‹ è£•ä¿¡, é–€å†… æ­£å’Œ , åŒ—åž£ é«˜æˆ, å–œå¤š ä¼¸ä¹‹, éŸ³ç”° å¼˜, å®‰è—¤ æ…¶æ˜­, ç¥žå¾³ å¾¹é›„, "OpenRTMã®ãŸã‚ã®ï¼“æ¬¡å…ƒã‚¹ãƒ†ãƒ¬ã‚ªè¦–è¦šèªè­˜ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã®å®Ÿè£…", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2006 (SI2006), p.3B2-4, 2006.12, æœ­å¹Œ, åŒ—æµ·é“ &ref(SI2006_Takahashi_3B2_4.pdf, [PDF]);
 
-**˜_•¶ŒöŠJ‹K’è‚É‚Â‚¢‚Ä
-–{ƒy[ƒW‚Å‚ÍAŠeŠw‰ï‚Ì˜_•¶ŒöŠJ‹K’è‚É]‚Á‚Ä‰Â”\‚ÈŒÀ‚è˜_•¶Œ´e‚ÌŒöŠJ‚ðs‚Á‚Ä‚¨‚è‚Ü‚·B
+**è«–æ–‡å…¬é–‹è¦å®šã«ã¤ã„ã¦
+æœ¬ãƒšãƒ¼ã‚¸ã§ã¯ã€å„å­¦ä¼šã®è«–æ–‡å…¬é–‹è¦å®šã«å¾“ã£ã¦å¯èƒ½ãªé™ã‚Šè«–æ–‡åŽŸç¨¿ã®å…¬é–‹ã‚’è¡Œã£ã¦ãŠã‚Šã¾ã™ã€‚
 
--[[ƒƒ{ƒbƒgŠw‰ï:http://www.rsj.or.jp/JRSJ/kaitei_20060215.html]]
---–{l‚ªŽ©g‚¨‚æ‚ÑŠ‘®‹@ŠÖ‚ÌWebƒy[ƒW‚ÅŒöŠJ‚·‚éŒÀ‚è‹–‘ø‚³‚ê‚éB
--[[“ú–{‹@ŠBŠw‰ï:http://www.jsme.or.jp/publish/yoko/yokob_t.htm]]
---–{l‚ªŽ©g‚¨‚æ‚ÑŠ‘®‹@ŠÖ‚ÌWebƒy[ƒW‚ÅŒöŠJ‚·‚éŒÀ‚è‹–‘ø‚³‚ê‚éB
+-[[ãƒ­ãƒœãƒƒãƒˆå­¦ä¼š:http://www.rsj.or.jp/JRSJ/kaitei_20060215.html]]
+--æœ¬äººãŒè‡ªèº«ãŠã‚ˆã³æ‰€å±žæ©Ÿé–¢ã®Webãƒšãƒ¼ã‚¸ã§å…¬é–‹ã™ã‚‹é™ã‚Šè¨±è«¾ã•ã‚Œã‚‹ã€‚
+-[[æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š:http://www.jsme.or.jp/publish/yoko/yokob_t.htm]]
+--æœ¬äººãŒè‡ªèº«ãŠã‚ˆã³æ‰€å±žæ©Ÿé–¢ã®Webãƒšãƒ¼ã‚¸ã§å…¬é–‹ã™ã‚‹é™ã‚Šè¨±è«¾ã•ã‚Œã‚‹ã€‚

--- a/Research_and_Development/Publication/paper_2007_ja.txt
+++ b/Research_and_Development/Publication/paper_2007_ja.txt
@@ -1,31 +1,31 @@
-// Title: ˜_•¶ (2007”N)
+// Title: è«–æ–‡ (2007å¹´)
 #contents
 
-**‘“àŠw‰ï 
-+Œ´ —C•ã, ‚‹´ VŒá, š ˆä N°, ˆÀ“¡ Œcº, "RTƒ~ƒhƒ‹ƒEƒGƒA‚ð—˜—p‚µ‚½ƒ‚ƒWƒ…[ƒ‹‚ÌŠK‘w‰»\¬‚É‚æ‚é‰“ŠuˆÚ“®ƒƒ{ƒbƒg‚ÌƒVƒXƒeƒ€ŒŸ“¢‹y‚ÑŠJ”­", ‘æ12‰ñ ƒƒ{ƒeƒBƒNƒXƒVƒ“ƒ|ƒWƒA, pp.498-503, 2007.03
-+“y‰® —T, …ì ^, ––œA ®Žm, ˆÀ“¡ Œcº, ’†–{ Œ[”V, ’r“Y –¾G, "RTƒ~ƒhƒ‹ƒEƒGƒA‚ð—p‚¢‚½•ªŽU§ŒäŒ^ƒƒ{ƒbƒg‚ÌŠJ”­", ‘æ12‰ñ ƒƒ{ƒeƒBƒNƒXƒVƒ“ƒ|ƒWƒA, pp.504-509, 2007.03
-+›š —Sª, ˆÀ“¡ Œcº, ––œA ®Žm, –kŠ_ ‚¬, _“¿ “O—Y, "OpenRTM aist ‚É‚æ‚éŽÀŽžŠÔ§Œä‚ðl—¶‚µ‚½RTƒRƒ“ƒ|[ƒlƒ“ƒg", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2007, p.1P1-A01, 2007.05, H“cŒ§, H“cŽs &ref(ROBOMEC07_Yoon_1P1-A01.pdf, [PDF]);
-+ˆÀ“¡ Œcº, _“¿ “O—Y, ––œA ®Žm, –kŠ_ ‚¬, "OMG RTC •W€Žd—l‚É€‹’‚µ‚½RT ƒ~ƒhƒ‹ƒEƒGƒA‚ÌŽÀ‘• OpenRTM-aist-0.4.0 V‹@”\‚ÌÐ‰î", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2007, p.1P1-A02, 2007.05, H“cŒ§, H“cŽs &ref(ROBOMEC07_Ando_1P1-A02.pdf, [PDF]);
-+ˆÀ“¡ Œcº, _“¿ “O—Y, ––œA ®Žm, –kŠ_ ‚¬, "RTƒ~ƒhƒ‹ƒEƒGƒA‚ðŠî”Õ‚Æ‚µ‚½ƒƒ{ƒbƒg“‡ŠJ”­ŠÂ‹«", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2007, p.1P1-A03, 2007.05, H“cŒ§, H“cŽs &ref(ROBOMEC07_Ando_1P1-A03.pdf, [PDF]);
-+Œº—t ½, ’†‘º Œ’, ˆÀ“¡ Œcº, _“¿ “O—Y, "RT ƒ~ƒhƒ‹ƒEƒFƒA‚É‚æ‚éŠwKE„˜_ƒRƒ“ƒ|[ƒlƒ“ƒg", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2007, p.1P1-B05, 2007.05, H“cŒ§, H“cŽs &ref(ROBOMEC07_Genba_1P1-B05.pdf, [PDF]);
-+ˆÀ“¡ Œcº, _“¿ “O—Y, â–{ •Žu, ŽR‰º ’q–ç, ’·£ ‰ÃG, "RT ƒ~ƒhƒ‹ƒEƒFƒA—pŠJ”­ŠÂ‹«‚Ì\’z", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2007, p.1P1-D04, 2007.05, H“cŒ§, H“cŽs &ref(ROBOMEC07_Sakamoto_1P1-D04.pdf, [PDF]);
-+“s“‡ —Ç‹v, VÈ ŽÀ•ÛŽq, ˆÀ“¡ Œcº, ‹´–{@G‹I, "RT ƒ~ƒhƒ‹ƒEƒFƒA‚É‚æ‚éî•ñ’ñŽ¦ƒVƒXƒeƒ€‚Ì\¬", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2007, p.2A2-K02, 2007.05, H“cŒ§, H“cŽs &ref(ROBOMEC07_Toshima_2A2-K02.pdf, [PDF]);
-+”ä—¯ì”Ž‹v, ‹àL •¶’j, ’†‰ª Tˆê˜Y, ––œA ®Žm, _“¿ “O—Y, ˆÀ“¡ Œcº, ’†‘º m•F, ŽRª Ž, Ö“¡ Œ³, ìŠp —Sˆê˜Y, "•ªŽUƒRƒ“ƒ|[ƒlƒ“ƒgŒ^ƒƒ{ƒbƒgƒVƒ~ƒ…ƒŒ[ƒ^OpenHRP3", ‘æ25‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.1I22, 2007.09, ç—tH‹Æ‘åŠw, ç—tŒ§ &ref(RSJ2007_Hirukawa_1I22.pdf, [PDF]);
-+ˆÀ“¡ Œcº, ‹àL •¶’j, ’†‰ª Tˆê˜Y, _“¿ “O—Y, ––œA ®Žm, ”ä—¯ì ”Ž‹v, "•ªŽUƒRƒ“ƒ|[ƒlƒ“ƒgŒ^ƒƒ{ƒbƒgƒVƒ~ƒ…ƒŒ[ƒ^OpenHRP3 -RTƒRƒ“ƒ|[ƒlƒ“ƒg‚ð—p‚¢‚½ŽÀ‹@‚Æ‰ÂŠ·‚È§Œäƒ\ƒtƒgƒEƒFƒAŠJ”­‹@”\-", ‘æ25‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.1I23, 2007.09, ç—tH‹Æ‘åŠw, ç—tŒ§ &ref(RSJ2007_Ando_1I23.pdf, [PDF]);
-+—é–Ø ‹ª, ‘åŒ´ Œ«ˆê, ˆÀ“¡ Œcº, ˜a“c ˜a‹`, ‘åê Œõ‘¾˜Y, ’J] ˜a—Y, "OMGƒ‚ƒfƒ‹‚É€‹’‚µ‚½Œy—ÊRTƒRƒ“ƒ|[ƒlƒ“ƒgFRTComponent-Lite-0.4.0‚ÌŠJ”­", ‘æ25‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.2I11, 2007.09, ç—tH‹Æ‘åŠw, ç—tŒ§ &ref(RSJ2007_Suzuki_2I11.pdf, [PDF]);
-+›Œ´ —²s, —› ÝŒM, ‘åŒ´ Œ«ˆê, ‰¹“c O, —Fš  L•Û, ‹à •òª, ˆÀ“¡ Œcº, ‘åê Œõ‘¾˜Y, "OpenRTM-aist-0.4.0‚ð—p‚¢‚½ƒ‚ƒoƒCƒ‹ƒ}ƒjƒsƒ…ƒŒ[ƒ^‚ÌŠî–{ƒRƒ“ƒ|[ƒlƒ“ƒg‚ÌŒŸ“¢", ‘æ25‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.2I12, 2007.09, ç—tH‹Æ‘åŠw, ç—tŒ§ &ref(RSJ2007_Sugawara_2I12.pdf, [PDF]);
-+ŽR–ì•Ó ‰ÄŽ÷, ˆÀ“¡ Œcº, Œ´ Œ÷, ‘åê Œõ‘¾˜Y, _“¿ “O—Y, ––œA ®Žm, ‘ “c ‰p”V, ’†–{ Œ[”V, _“c ^Ži, "“V‹Cî•ñŽæ“¾ƒRƒ“ƒ|[ƒlƒ“ƒg‚ÌŠJ”­ -RTƒ~ƒhƒ‹ƒEƒGƒAƒOƒ‹[ƒv‚Æƒƒ{ƒbƒgƒT[ƒrƒXƒCƒjƒVƒAƒ`ƒu‚Æ‚Ì˜AŒg-", ‘æ25‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.2I13, 2007.09, ç—tH‹Æ‘åŠw, ç—tŒ§ &ref(RSJ2007_Yamanobe_2I13.pdf, [PDF]);
-+ˆÀ“¡ Œcº, ´… ¹K, ›š —Sª, _“¿ “O—Y, "RTƒRƒ“ƒ|[ƒlƒ“ƒg‚ÌƒŠƒAƒ‹ƒ^ƒCƒ€‰»‚ðŽÀŒ»‚·‚éŽÀsƒRƒ“ƒeƒLƒXƒg‚ÌŠg’£", ‘æ25‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.2I14, 2007.09, ç—tH‹Æ‘åŠw, ç—tŒ§ &ref(RSJ2007_Ando_2I14.pdf, [PDF]);
-+´… ¹K, ˆÀ“¡ Œcº, ›š —Sª, ‰¹“c O, _“¿ “O—Y, "OpenRTM-aist-0.4.0‚É‚æ‚éƒqƒ…[ƒ}ƒmƒCƒhƒƒ{ƒbƒgHRP2‚ÌRTƒRƒ“ƒ|[ƒlƒ“ƒgŠJ”­", ‘æ25‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.2I15, 2007.09, ç—tH‹Æ‘åŠw, ç—tŒ§ &ref(RSJ2007_Shimizu_2I15.pdf, [PDF]);
-+—é–Ø ‹ª, ‘åŒ´ Œ«ˆê, ‰ºŽR ’¼‹I, ˆÀ“¡ Œcº, ‘åê Œõ‘¾˜Y, ˜a“c ˆê‹`, "ƒ†ƒrƒLƒ^ƒXEƒƒ{ƒbƒgEƒCƒ“ƒ^ƒtƒF[ƒX gFUSENh‚Ì’ñˆÄ ‘æ1•ñ@Šî”Õƒ\ƒtƒgƒEƒGƒAƒvƒ‰ƒbƒgƒtƒH[ƒ€‚ÌŒŸ“¢", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2007 (SI2007), p.1C2-2, 2007.12 &ref(SI2007_Suzuki_1C2_2.pdf, [PDF]);;
-+ŽR–ì•Ó ‰ÄŽ÷, ˆÀ“¡ Œcº, _“¿ “O—Y, "OpenRTM-aist‚É‚æ‚éWebƒT[ƒrƒXƒT[ƒoŒ^RTƒRƒ“ƒ|[ƒlƒ“ƒg‚ÌŠJ”­", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2007 (SI2007), p.1L3-2, 2007.12 &ref(SI2007_Yamanobe_1L3_2.pdf, [PDF]);
-+_“¿ “O—Y, ”ä—¯ì”Ž‹v, ’†‰ª Tˆê˜Y, ––œA ®Žm, ˆÀ“¡ Œcº, ’†‘º m•F, ŽRª Ž, Ö“¡ Œ³, ìŠp —Sˆê˜Y, "•ªŽUƒRƒ“ƒ|[ƒlƒ“ƒgŒ^ƒƒ{ƒbƒgƒVƒ~ƒ…ƒŒ[ƒ^OpenHRP3 ", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2007 (SI2007), p.3A1-2, 2007.12 &ref(SI2007_Kotoku_3A1_2.pdf, [PDF]);
-+ˆÀ“¡ Œcº, ´… ¹K, ›š —Sª, _“¿ “O—Y, ˆÀ“¡ Œcº, "RTƒRƒ“ƒ|[ƒlƒ“ƒg‚Ì‘½—l‚ÈŽÀs‚ðŽÀŒ»‚·‚éŽÀsƒRƒ“ƒeƒLƒXƒg‚ÌŠg’£", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2007 (SI2007), p.3A1-5, 2007.12 &ref(SI2007_Ando_3A1_5.pdf, [PDF]);
+**å›½å†…å­¦ä¼š 
++åŽŸ ä½‘è¼”, é«˜æ©‹ æ–°å¾, åœ‹äº• åº·æ™´, å®‰è—¤ æ…¶æ˜­, "RTãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢ã‚’åˆ©ç”¨ã—ãŸãƒ¢ã‚¸ãƒ¥ãƒ¼ãƒ«ã®éšŽå±¤åŒ–æ§‹æˆã«ã‚ˆã‚‹é éš”ç§»å‹•ãƒ­ãƒœãƒƒãƒˆã®ã‚·ã‚¹ãƒ†ãƒ æ¤œè¨ŽåŠã³é–‹ç™º", ç¬¬12å›ž ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ã‚·ãƒ³ãƒã‚¸ã‚¢, pp.498-503, 2007.03
++åœŸå±‹ è£•, æ°´å· çœŸ, æœ«å»£ å°šå£«, å®‰è—¤ æ…¶æ˜­, ä¸­æœ¬ å•“ä¹‹, æ± æ·» æ˜Žå®, "RTãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢ã‚’ç”¨ã„ãŸåˆ†æ•£åˆ¶å¾¡åž‹ãƒ­ãƒœãƒƒãƒˆã®é–‹ç™º", ç¬¬12å›ž ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ã‚·ãƒ³ãƒã‚¸ã‚¢, pp.504-509, 2007.03
++å°¹ ç¥æ ¹, å®‰è—¤ æ…¶æ˜­, æœ«å»£ å°šå£«, åŒ—åž£ é«˜æˆ, ç¥žå¾³ å¾¹é›„, "OpenRTM aist ã«ã‚ˆã‚‹å®Ÿæ™‚é–“åˆ¶å¾¡ã‚’è€ƒæ…®ã—ãŸRTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆ", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2007, p.1P1-A01, 2007.05, ç§‹ç”°çœŒ, ç§‹ç”°å¸‚ &ref(ROBOMEC07_Yoon_1P1-A01.pdf, [PDF]);
++å®‰è—¤ æ…¶æ˜­, ç¥žå¾³ å¾¹é›„, æœ«å»£ å°šå£«, åŒ—åž£ é«˜æˆ, "OMG RTC æ¨™æº–ä»•æ§˜ã«æº–æ‹ ã—ãŸRT ãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢ã®å®Ÿè£… OpenRTM-aist-0.4.0 æ–°æ©Ÿèƒ½ã®ç´¹ä»‹", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2007, p.1P1-A02, 2007.05, ç§‹ç”°çœŒ, ç§‹ç”°å¸‚ &ref(ROBOMEC07_Ando_1P1-A02.pdf, [PDF]);
++å®‰è—¤ æ…¶æ˜­, ç¥žå¾³ å¾¹é›„, æœ«å»£ å°šå£«, åŒ—åž£ é«˜æˆ, "RTãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢ã‚’åŸºç›¤ã¨ã—ãŸãƒ­ãƒœãƒƒãƒˆçµ±åˆé–‹ç™ºç’°å¢ƒ", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2007, p.1P1-A03, 2007.05, ç§‹ç”°çœŒ, ç§‹ç”°å¸‚ &ref(ROBOMEC07_Ando_1P1-A03.pdf, [PDF]);
++çŽ„è‘‰ èª , ä¸­æ‘ å¥, å®‰è—¤ æ…¶æ˜­, ç¥žå¾³ å¾¹é›„, "RT ãƒŸãƒ‰ãƒ«ã‚¦ã‚§ã‚¢ã«ã‚ˆã‚‹å­¦ç¿’ãƒ»æŽ¨è«–ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆ", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2007, p.1P1-B05, 2007.05, ç§‹ç”°çœŒ, ç§‹ç”°å¸‚ &ref(ROBOMEC07_Genba_1P1-B05.pdf, [PDF]);
++å®‰è—¤ æ…¶æ˜­, ç¥žå¾³ å¾¹é›„, å‚æœ¬ æ­¦å¿—, å±±ä¸‹ æ™ºä¹Ÿ, é•·ç€¬ å˜‰ç§€, "RT ãƒŸãƒ‰ãƒ«ã‚¦ã‚§ã‚¢ç”¨é–‹ç™ºç’°å¢ƒã®æ§‹ç¯‰", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2007, p.1P1-D04, 2007.05, ç§‹ç”°çœŒ, ç§‹ç”°å¸‚ &ref(ROBOMEC07_Sakamoto_1P1-D04.pdf, [PDF]);
++éƒ½å³¶ è‰¯ä¹…, æ–°å¦» å®Ÿä¿å­, å®‰è—¤ æ…¶æ˜­, æ©‹æœ¬ã€€ç§€ç´€, "RT ãƒŸãƒ‰ãƒ«ã‚¦ã‚§ã‚¢ã«ã‚ˆã‚‹æƒ…å ±æç¤ºã‚·ã‚¹ãƒ†ãƒ ã®æ§‹æˆ", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2007, p.2A2-K02, 2007.05, ç§‹ç”°çœŒ, ç§‹ç”°å¸‚ &ref(ROBOMEC07_Toshima_2A2-K02.pdf, [PDF]);
++æ¯”ç•™å·åšä¹…, é‡‘åºƒ æ–‡ç”·, ä¸­å²¡ æ…Žä¸€éƒŽ, æœ«å»£ å°šå£«, ç¥žå¾³ å¾¹é›„, å®‰è—¤ æ…¶æ˜­, ä¸­æ‘ ä»å½¦, å±±æ ¹ å…‹, æ–Žè—¤ å…ƒ, å·è§’ ç¥ä¸€éƒŽ, "åˆ†æ•£ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆåž‹ãƒ­ãƒœãƒƒãƒˆã‚·ãƒŸãƒ¥ãƒ¬ãƒ¼ã‚¿OpenHRP3", ç¬¬25å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.1I22, 2007.09, åƒè‘‰å·¥æ¥­å¤§å­¦, åƒè‘‰çœŒ &ref(RSJ2007_Hirukawa_1I22.pdf, [PDF]);
++å®‰è—¤ æ…¶æ˜­, é‡‘åºƒ æ–‡ç”·, ä¸­å²¡ æ…Žä¸€éƒŽ, ç¥žå¾³ å¾¹é›„, æœ«å»£ å°šå£«, æ¯”ç•™å· åšä¹…, "åˆ†æ•£ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆåž‹ãƒ­ãƒœãƒƒãƒˆã‚·ãƒŸãƒ¥ãƒ¬ãƒ¼ã‚¿OpenHRP3 -RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã‚’ç”¨ã„ãŸå®Ÿæ©Ÿã¨å¯æ›ãªåˆ¶å¾¡ã‚½ãƒ•ãƒˆã‚¦ã‚§ã‚¢é–‹ç™ºæ©Ÿèƒ½-", ç¬¬25å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.1I23, 2007.09, åƒè‘‰å·¥æ¥­å¤§å­¦, åƒè‘‰çœŒ &ref(RSJ2007_Ando_1I23.pdf, [PDF]);
++éˆ´æœ¨ å–¬, å¤§åŽŸ è³¢ä¸€, å®‰è—¤ æ…¶æ˜­, å’Œç”° å’Œç¾©, å¤§å ´ å…‰å¤ªéƒŽ, è°·æ±Ÿ å’Œé›„, "OMGãƒ¢ãƒ‡ãƒ«ã«æº–æ‹ ã—ãŸè»½é‡RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆï¼šRTComponent-Lite-0.4.0ã®é–‹ç™º", ç¬¬25å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.2I11, 2007.09, åƒè‘‰å·¥æ¥­å¤§å­¦, åƒè‘‰çœŒ &ref(RSJ2007_Suzuki_2I11.pdf, [PDF]);
++è…åŽŸ éš†è¡Œ, æŽ åœ¨å‹², å¤§åŽŸ è³¢ä¸€, éŸ³ç”° å¼˜, å‹åœ‹ ä¼¸ä¿, é‡‘ å¥‰æ ¹, å®‰è—¤ æ…¶æ˜­, å¤§å ´ å…‰å¤ªéƒŽ, "OpenRTM-aist-0.4.0ã‚’ç”¨ã„ãŸãƒ¢ãƒã‚¤ãƒ«ãƒžãƒ‹ãƒ”ãƒ¥ãƒ¬ãƒ¼ã‚¿ã®åŸºæœ¬ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã®æ¤œè¨Ž", ç¬¬25å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.2I12, 2007.09, åƒè‘‰å·¥æ¥­å¤§å­¦, åƒè‘‰çœŒ &ref(RSJ2007_Sugawara_2I12.pdf, [PDF]);
++å±±é‡Žè¾º å¤æ¨¹, å®‰è—¤ æ…¶æ˜­, åŽŸ åŠŸ, å¤§å ´ å…‰å¤ªéƒŽ, ç¥žå¾³ å¾¹é›„, æœ«å»£ å°šå£«, è”µç”° è‹±ä¹‹, ä¸­æœ¬ å•“ä¹‹, ç¥žç”° çœŸå¸, "å¤©æ°—æƒ…å ±å–å¾—ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã®é–‹ç™º -RTãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢ã‚°ãƒ«ãƒ¼ãƒ—ã¨ãƒ­ãƒœãƒƒãƒˆã‚µãƒ¼ãƒ“ã‚¹ã‚¤ãƒ‹ã‚·ã‚¢ãƒãƒ–ã¨ã®é€£æº-", ç¬¬25å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.2I13, 2007.09, åƒè‘‰å·¥æ¥­å¤§å­¦, åƒè‘‰çœŒ &ref(RSJ2007_Yamanobe_2I13.pdf, [PDF]);
++å®‰è—¤ æ…¶æ˜­, æ¸…æ°´ æ˜Œå¹¸, å°¹ ç¥æ ¹, ç¥žå¾³ å¾¹é›„, "RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã®ãƒªã‚¢ãƒ«ã‚¿ã‚¤ãƒ åŒ–ã‚’å®Ÿç¾ã™ã‚‹å®Ÿè¡Œã‚³ãƒ³ãƒ†ã‚­ã‚¹ãƒˆã®æ‹¡å¼µ", ç¬¬25å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.2I14, 2007.09, åƒè‘‰å·¥æ¥­å¤§å­¦, åƒè‘‰çœŒ &ref(RSJ2007_Ando_2I14.pdf, [PDF]);
++æ¸…æ°´ æ˜Œå¹¸, å®‰è—¤ æ…¶æ˜­, å°¹ ç¥æ ¹, éŸ³ç”° å¼˜, ç¥žå¾³ å¾¹é›„, "OpenRTM-aist-0.4.0ã«ã‚ˆã‚‹ãƒ’ãƒ¥ãƒ¼ãƒžãƒŽã‚¤ãƒ‰ãƒ­ãƒœãƒƒãƒˆHRP2ã®RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆé–‹ç™º", ç¬¬25å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.2I15, 2007.09, åƒè‘‰å·¥æ¥­å¤§å­¦, åƒè‘‰çœŒ &ref(RSJ2007_Shimizu_2I15.pdf, [PDF]);
++éˆ´æœ¨ å–¬, å¤§åŽŸ è³¢ä¸€, ä¸‹å±± ç›´ç´€, å®‰è—¤ æ…¶æ˜­, å¤§å ´ å…‰å¤ªéƒŽ, å’Œç”° ä¸€ç¾©, "ãƒ¦ãƒ“ã‚­ã‚¿ã‚¹ãƒ»ãƒ­ãƒœãƒƒãƒˆãƒ»ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ â€œFUSENâ€ã®ææ¡ˆ ç¬¬1å ±ã€€åŸºç›¤ã‚½ãƒ•ãƒˆã‚¦ã‚¨ã‚¢ãƒ—ãƒ©ãƒƒãƒˆãƒ•ã‚©ãƒ¼ãƒ ã®æ¤œè¨Ž", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2007 (SI2007), p.1C2-2, 2007.12 &ref(SI2007_Suzuki_1C2_2.pdf, [PDF]);;
++å±±é‡Žè¾º å¤æ¨¹, å®‰è—¤ æ…¶æ˜­, ç¥žå¾³ å¾¹é›„, "OpenRTM-aistã«ã‚ˆã‚‹Webã‚µãƒ¼ãƒ“ã‚¹ã‚µãƒ¼ãƒåž‹RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã®é–‹ç™º", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2007 (SI2007), p.1L3-2, 2007.12 &ref(SI2007_Yamanobe_1L3_2.pdf, [PDF]);
++ç¥žå¾³ å¾¹é›„, æ¯”ç•™å·åšä¹…, ä¸­å²¡ æ…Žä¸€éƒŽ, æœ«å»£ å°šå£«, å®‰è—¤ æ…¶æ˜­, ä¸­æ‘ ä»å½¦, å±±æ ¹ å…‹, æ–Žè—¤ å…ƒ, å·è§’ ç¥ä¸€éƒŽ, "åˆ†æ•£ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆåž‹ãƒ­ãƒœãƒƒãƒˆã‚·ãƒŸãƒ¥ãƒ¬ãƒ¼ã‚¿OpenHRP3 ", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2007 (SI2007), p.3A1-2, 2007.12 &ref(SI2007_Kotoku_3A1_2.pdf, [PDF]);
++å®‰è—¤ æ…¶æ˜­, æ¸…æ°´ æ˜Œå¹¸, å°¹ ç¥æ ¹, ç¥žå¾³ å¾¹é›„, å®‰è—¤ æ…¶æ˜­, "RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã®å¤šæ§˜ãªå®Ÿè¡Œã‚’å®Ÿç¾ã™ã‚‹å®Ÿè¡Œã‚³ãƒ³ãƒ†ã‚­ã‚¹ãƒˆã®æ‹¡å¼µ", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2007 (SI2007), p.3A1-5, 2007.12 &ref(SI2007_Ando_3A1_5.pdf, [PDF]);
 
-**˜_•¶ŒöŠJ‹K’è‚É‚Â‚¢‚Ä 
-–{ƒy[ƒW‚Å‚ÍAŠeŠw‰ï‚Ì˜_•¶ŒöŠJ‹K’è‚É]‚Á‚Ä‰Â”\‚ÈŒÀ‚è˜_•¶Œ´e‚ÌŒöŠJ‚ðs‚Á‚Ä‚¨‚è‚Ü‚·B
+**è«–æ–‡å…¬é–‹è¦å®šã«ã¤ã„ã¦ 
+æœ¬ãƒšãƒ¼ã‚¸ã§ã¯ã€å„å­¦ä¼šã®è«–æ–‡å…¬é–‹è¦å®šã«å¾“ã£ã¦å¯èƒ½ãªé™ã‚Šè«–æ–‡åŽŸç¨¿ã®å…¬é–‹ã‚’è¡Œã£ã¦ãŠã‚Šã¾ã™ã€‚
 
--[[ƒƒ{ƒbƒgŠw‰ï:http://www.rsj.or.jp/JRSJ/kaitei_20060215.html]]
---–{l‚ªŽ©g‚¨‚æ‚ÑŠ‘®‹@ŠÖ‚ÌWebƒy[ƒW‚ÅŒöŠJ‚·‚éŒÀ‚è‹–‘ø‚³‚ê‚éB
--[[“ú–{‹@ŠBŠw‰ï:http://www.jsme.or.jp/publish/yoko/yokob_t.htm]]
---–{l‚ªŽ©g‚¨‚æ‚ÑŠ‘®‹@ŠÖ‚ÌWebƒy[ƒW‚ÅŒöŠJ‚·‚éŒÀ‚è‹–‘ø‚³‚ê‚éB
+-[[ãƒ­ãƒœãƒƒãƒˆå­¦ä¼š:http://www.rsj.or.jp/JRSJ/kaitei_20060215.html]]
+--æœ¬äººãŒè‡ªèº«ãŠã‚ˆã³æ‰€å±žæ©Ÿé–¢ã®Webãƒšãƒ¼ã‚¸ã§å…¬é–‹ã™ã‚‹é™ã‚Šè¨±è«¾ã•ã‚Œã‚‹ã€‚
+-[[æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š:http://www.jsme.or.jp/publish/yoko/yokob_t.htm]]
+--æœ¬äººãŒè‡ªèº«ãŠã‚ˆã³æ‰€å±žæ©Ÿé–¢ã®Webãƒšãƒ¼ã‚¸ã§å…¬é–‹ã™ã‚‹é™ã‚Šè¨±è«¾ã•ã‚Œã‚‹ã€‚

--- a/Research_and_Development/Publication/paper_2008_ja.txt
+++ b/Research_and_Development/Publication/paper_2008_ja.txt
@@ -1,30 +1,30 @@
-// Title: ˜_•¶ (2008”N)
+// Title: è«–æ–‡ (2008å¹´)
 #contents
 
-** ˜_•¶Ž
-+ˆÀ“¡ Œcº, ’†‰ªTˆê˜Y, _“¿“O—Y, "•ªŽUƒRƒ“ƒ|[ƒlƒ“ƒgŒ^ƒƒ{ƒbƒgƒVƒ~ƒ…ƒŒ[ƒ^EƒA[ƒLƒeƒNƒ`ƒƒ-RTƒRƒ“ƒ|[ƒlƒ“ƒg‚ð—p‚¢‚½ŽÀ‹@‚Æ‰ÂŠ·‚È§Œäƒ\ƒtƒgƒEƒFƒAŠJ”­‹@”\-", “ú–{ƒƒ{ƒbƒgŠw‰ïŽ, Vol.26, No.5, pp.19-22, 2008.06, 0289-1824 &ref(RSJ_Vol_26_No_05_2605B019.pdf,[PDF]);
+** è«–æ–‡èªŒ
++å®‰è—¤ æ…¶æ˜­, ä¸­å²¡æ…Žä¸€éƒŽ, ç¥žå¾³å¾¹é›„, "åˆ†æ•£ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆåž‹ãƒ­ãƒœãƒƒãƒˆã‚·ãƒŸãƒ¥ãƒ¬ãƒ¼ã‚¿ãƒ»ã‚¢ãƒ¼ã‚­ãƒ†ã‚¯ãƒãƒ£-RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã‚’ç”¨ã„ãŸå®Ÿæ©Ÿã¨å¯æ›ãªåˆ¶å¾¡ã‚½ãƒ•ãƒˆã‚¦ã‚§ã‚¢é–‹ç™ºæ©Ÿèƒ½-", æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šèªŒ, Vol.26, No.5, pp.19-22, 2008.06, 0289-1824 &ref(RSJ_Vol_26_No_05_2605B019.pdf,[PDF]);
 
-** ‘ÛŠw‰ï
+** å›½éš›å­¦ä¼š
 
 +Noriaki ANDO, Takashi SUEHIRO, Tetsuo KOTOKU, "A Software Platform for Component Based RT-System Development: OpenRTM-Aist", International Conference on SIMULATION, MODELING and PROGRAMMING for AUTONOMOUS ROBOTS (SIMPAR 2008), pp.87-98, 2008.11, Venice, Italy, ISSN 0302-9743 &ref(SIMPAR2008_Ando.pdf,[PDF]);
 +Yujin Wakita, Natsuki Yamanobe, Kazuyuki Nagata, Noriaki ANDO, Clerc Mathias, "Development of User Interface with Single Switch Scanning for Robot Arm to Help Disabled People Using RT-Middleware ", Proceedings of The 10th International Conference on Control, Automation, Robotics and Vision, ICARCV 2008, pp.1515-1520, 2008.12, Hanoi, Vietnam &ref(ICARCV2008_Wakita.pdf,[PDF]);
 
 
-** ‘“àŠw‰ï
+** å›½å†…å­¦ä¼š
 
-+ˆÀ“¡ Œcº, ´… ¹K, _“¿ “O—Y, "RTƒRƒ“ƒ|[ƒlƒ“ƒgŠÔ‚Ìƒf[ƒ^‘—ŽóM•û–@‚ÉŠÖ‚·‚élŽ@", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2008, p.1P1-E08, 2008.06, ’·–ì &ref(ROBOMEC08_Ando_1P1-E08.pdf,[PDF]);
-+‰i“c ˜a”V, ˜e“c —Dm, ŽR–ì•Ó ‰ÄŽ÷, ˆÀ“¡ Œcº, "OpenRTM-aist ‚É‚æ‚é‰î•ƒƒ{ƒbƒg‘€ìƒCƒ“ƒ^ƒtƒF[ƒXƒRƒ“ƒ|[ƒlƒ“ƒg‚ÌŠJ”­", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2008, p.2P2-F18, 2008.06, ’·–ì &ref(ROBOMEC08_Nagata_2P2-F18.pdf,[PDF]);
-+´… ¹K, ›š —Sª, ‰¹“c O, ˆÀ“¡ Œcº, _“¿ “O—Y, "RTƒRƒ“ƒ|[ƒlƒ“ƒg‚É‚æ‚éÄ—˜—p‰Â”\‚Èì‹ÆƒXƒLƒ‹‚ÌŽÀŒ»", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2008, p.1P2-E14, 2008.06, ’·–ì &ref(ROBOMEC08_Shimizu_1P1-E14.pdf,[PDF]);
-+ˆÀ“¡ Œcº, â–{•Žu, ’†–{Œ[”V, "OpenRT Platform/RTƒ~ƒhƒ‹ƒEƒGƒAEƒc[ƒ‹ƒ`ƒF[ƒ“‚Ì‚½‚ß‚Ìƒ‚ƒWƒ…[ƒ‹‚¨‚æ‚ÑƒVƒXƒeƒ€Žd—l‹Lq•ûŽ®", ‘æ26‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.1F1-03, 2008.09 &ref(RSJ2008_Ando_1F1-03.pdf,[PDF]);
-+ˆÀ“¡ Œcº, ’†‰ªTˆê˜Y, _“¿ “O—Y, ”ä—¯ì”Ž‹v, "RTƒRƒ“ƒ|[ƒlƒ“ƒg‚É‚æ‚éOpenHRP3§Œäƒ\ƒtƒgƒEƒGƒAŠJ”­ -RTƒ~ƒhƒ‹ƒEƒGƒA‚ðŠî”Õ‚Æ‚µ‚½•ªŽUƒRƒ“ƒ|[ƒlƒ“ƒgŒ^ƒƒ{ƒbƒgƒVƒ~ƒ…ƒŒ[ƒ^-", ‘æ26‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.3G3-03, 2008.09 &ref(RSJ2008_Ando_3G3-03.pdf,[PDF]);
-+Masayoshi Yokomachi, Makoto Mizukawa, Shigeoki Hirai, Takashi Suehiro, Tetsuo Kotoku, Noriaki Ando, "RT middleware and it's International Standardization Activity in OMG", ‘æ26‰ñ “ú–{ƒƒ{ƒbƒgŠw‰ïŠwpu‰‰‰ï—\eW, p.2G1-05, 2008.09 &ref(RSJ2008_Yokomachi_2G1-05.pdf,[PDF]);
-+ˆÀ“¡ Œcº, "OpenRTM-aist-1.0‚ÌV‹@”\", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2008 (SI2008), p.2L1-3, 2008.12, Šò•ŒŒ§ &ref(SI2008_Ando_2L1_3.pdf,[PDF]);
-+_“¿ “O—Y, ”ä—¯ì”Ž‹v, ’†‰ªTˆê˜Y, ––œA ®Žm, ˆÀ“¡ Œcº, ’†‘ºm•F, ŽRªŽ, âV“¡Œ³CìŠp—Sˆê˜Y, "•ªŽUƒRƒ“ƒ|[ƒlƒ“ƒgŒ^ƒƒ{ƒbƒgƒVƒ~ƒ…ƒŒ[ƒ^OpenHRP3", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2008 (SI2008), p.1L2-5, 2008.12, Šò•ŒŒ§ &ref(SI2008_Kotoku_1L2_5.pdf,[PDF]);
++å®‰è—¤ æ…¶æ˜­, æ¸…æ°´ æ˜Œå¹¸, ç¥žå¾³ å¾¹é›„, "RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆé–“ã®ãƒ‡ãƒ¼ã‚¿é€å—ä¿¡æ–¹æ³•ã«é–¢ã™ã‚‹è€ƒå¯Ÿ", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2008, p.1P1-E08, 2008.06, é•·é‡Ž &ref(ROBOMEC08_Ando_1P1-E08.pdf,[PDF]);
++æ°¸ç”° å’Œä¹‹, è„‡ç”° å„ªä», å±±é‡Žè¾º å¤æ¨¹, å®‰è—¤ æ…¶æ˜­, "OpenRTM-aist ã«ã‚ˆã‚‹ä»‹åŠ©ãƒ­ãƒœãƒƒãƒˆæ“ä½œã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã®é–‹ç™º", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2008, p.2P2-F18, 2008.06, é•·é‡Ž &ref(ROBOMEC08_Nagata_2P2-F18.pdf,[PDF]);
++æ¸…æ°´ æ˜Œå¹¸, å°¹ ç¥æ ¹, éŸ³ç”° å¼˜, å®‰è—¤ æ…¶æ˜­, ç¥žå¾³ å¾¹é›„, "RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã«ã‚ˆã‚‹å†åˆ©ç”¨å¯èƒ½ãªä½œæ¥­ã‚¹ã‚­ãƒ«ã®å®Ÿç¾", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2008, p.1P2-E14, 2008.06, é•·é‡Ž &ref(ROBOMEC08_Shimizu_1P1-E14.pdf,[PDF]);
++å®‰è—¤ æ…¶æ˜­, å‚æœ¬æ­¦å¿—, ä¸­æœ¬å•“ä¹‹, "OpenRT Platform/RTãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢ãƒ»ãƒ„ãƒ¼ãƒ«ãƒã‚§ãƒ¼ãƒ³ã®ãŸã‚ã®ãƒ¢ã‚¸ãƒ¥ãƒ¼ãƒ«ãŠã‚ˆã³ã‚·ã‚¹ãƒ†ãƒ ä»•æ§˜è¨˜è¿°æ–¹å¼", ç¬¬26å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.1F1-03, 2008.09 &ref(RSJ2008_Ando_1F1-03.pdf,[PDF]);
++å®‰è—¤ æ…¶æ˜­, ä¸­å²¡æ…Žä¸€éƒŽ, ç¥žå¾³ å¾¹é›„, æ¯”ç•™å·åšä¹…, "RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã«ã‚ˆã‚‹OpenHRP3åˆ¶å¾¡ã‚½ãƒ•ãƒˆã‚¦ã‚¨ã‚¢é–‹ç™º -RTãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢ã‚’åŸºç›¤ã¨ã—ãŸåˆ†æ•£ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆåž‹ãƒ­ãƒœãƒƒãƒˆã‚·ãƒŸãƒ¥ãƒ¬ãƒ¼ã‚¿-", ç¬¬26å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.3G3-03, 2008.09 &ref(RSJ2008_Ando_3G3-03.pdf,[PDF]);
++Masayoshi Yokomachi, Makoto Mizukawa, Shigeoki Hirai, Takashi Suehiro, Tetsuo Kotoku, Noriaki Ando, "RT middleware and it's International Standardization Activity in OMG", ç¬¬26å›ž æ—¥æœ¬ãƒ­ãƒœãƒƒãƒˆå­¦ä¼šå­¦è¡“è¬›æ¼”ä¼šäºˆç¨¿é›†, p.2G1-05, 2008.09 &ref(RSJ2008_Yokomachi_2G1-05.pdf,[PDF]);
++å®‰è—¤ æ…¶æ˜­, "OpenRTM-aist-1.0ã®æ–°æ©Ÿèƒ½", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2008 (SI2008), p.2L1-3, 2008.12, å²é˜œçœŒ &ref(SI2008_Ando_2L1_3.pdf,[PDF]);
++ç¥žå¾³ å¾¹é›„, æ¯”ç•™å·åšä¹…, ä¸­å²¡æ…Žä¸€éƒŽ, æœ«å»£ å°šå£«, å®‰è—¤ æ…¶æ˜­, ä¸­æ‘ä»å½¦, å±±æ ¹å…‹, é½‹è—¤å…ƒï¼Œå·è§’ç¥ä¸€éƒŽ, "åˆ†æ•£ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆåž‹ãƒ­ãƒœãƒƒãƒˆã‚·ãƒŸãƒ¥ãƒ¬ãƒ¼ã‚¿OpenHRP3", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2008 (SI2008), p.1L2-5, 2008.12, å²é˜œçœŒ &ref(SI2008_Kotoku_1L2_5.pdf,[PDF]);
 
-**˜_•¶ŒöŠJ‹K’è‚É‚Â‚¢‚Ä 
-–{ƒy[ƒW‚Å‚ÍAŠeŠw‰ï‚Ì˜_•¶ŒöŠJ‹K’è‚É]‚Á‚Ä‰Â”\‚ÈŒÀ‚è˜_•¶Œ´e‚ÌŒöŠJ‚ðs‚Á‚Ä‚¨‚è‚Ü‚·B
+**è«–æ–‡å…¬é–‹è¦å®šã«ã¤ã„ã¦ 
+æœ¬ãƒšãƒ¼ã‚¸ã§ã¯ã€å„å­¦ä¼šã®è«–æ–‡å…¬é–‹è¦å®šã«å¾“ã£ã¦å¯èƒ½ãªé™ã‚Šè«–æ–‡åŽŸç¨¿ã®å…¬é–‹ã‚’è¡Œã£ã¦ãŠã‚Šã¾ã™ã€‚
 
--[[ƒƒ{ƒbƒgŠw‰ï:http://www.rsj.or.jp/JRSJ/kaitei_20060215.html]]
---–{l‚ªŽ©g‚¨‚æ‚ÑŠ‘®‹@ŠÖ‚ÌWebƒy[ƒW‚ÅŒöŠJ‚·‚éŒÀ‚è‹–‘ø‚³‚ê‚éB
--[[“ú–{‹@ŠBŠw‰ï:http://www.jsme.or.jp/publish/yoko/yokob_t.htm]]
---–{l‚ªŽ©g‚¨‚æ‚ÑŠ‘®‹@ŠÖ‚ÌWebƒy[ƒW‚ÅŒöŠJ‚·‚éŒÀ‚è‹–‘ø‚³‚ê‚éB
+-[[ãƒ­ãƒœãƒƒãƒˆå­¦ä¼š:http://www.rsj.or.jp/JRSJ/kaitei_20060215.html]]
+--æœ¬äººãŒè‡ªèº«ãŠã‚ˆã³æ‰€å±žæ©Ÿé–¢ã®Webãƒšãƒ¼ã‚¸ã§å…¬é–‹ã™ã‚‹é™ã‚Šè¨±è«¾ã•ã‚Œã‚‹ã€‚
+-[[æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š:http://www.jsme.or.jp/publish/yoko/yokob_t.htm]]
+--æœ¬äººãŒè‡ªèº«ãŠã‚ˆã³æ‰€å±žæ©Ÿé–¢ã®Webãƒšãƒ¼ã‚¸ã§å…¬é–‹ã™ã‚‹é™ã‚Šè¨±è«¾ã•ã‚Œã‚‹ã€‚

--- a/Research_and_Development/Publication/paper_2009_ja.txt
+++ b/Research_and_Development/Publication/paper_2009_ja.txt
@@ -1,28 +1,28 @@
-// Title: ˜_•¶ (2009”N)
+// Title: è«–æ–‡ (2009å¹´)
 #contents
 
-** ˜_•¶Ž
+** è«–æ–‡èªŒ
 +Noriaki ANDO, Kenichi OHARA, Takashi SUZUKI, Kohtaro OHBA, "RTC-Lite: Lightweight RT-Component for Distributed Embedded Systems", SICE Journal of Control, Measurement, and System Integration (SICE JCMSI), Vol.2, No.6, pp.328-333, 2009.11, ISSN 1882-4889 &ref(SICE_JCMSI_Ando.pdf,[PDF]);
 
-** ‘ÛŠw‰ï
+** å›½éš›å­¦ä¼š
 
-+Yoshiji Yasu, Kazuo Nakayoshi, H Sendai, E Inoue, M Tanaka, S Suzuki, S Satoh, S Muto, T Otomo, T Nakatani, T Uchida, Noriaki ANDO, Tetsuo KOTOKU, Satoshi HIRANO, "Development of DAQ-Middleware", CHEP'09. 17th International Conference on Computing in High Energy and Nuclear Physics, 2009.03, ƒvƒ‰ƒn, ƒ`ƒFƒR, http://www.iop.org/EJ/volume/1742-6596/2009 &ref(SI2009_Suzuki_3D1_1.pdf,[PDF]);
-+Tamio Tanikawa, Ohara Ken'ichi, Hiroyuki Nakamoto , Masato Iijima, Noriaki ANDO, Takeshi SAKAMOTO, Tetsuo KOTOKU, Kotaro OHBA, Tatsuo ARAI, "Smart home for security and low power consumption based on Ubiquitous Robotics", The 6th International Conference on Ubiquitous Robots and Ambient Intelligence (URAI 2009), pp.185-188, 2009.10, ŠØ‘AŒõB &ref(URAI2009_tanikawa.pdf,[PDF]);
++Yoshiji Yasu, Kazuo Nakayoshi, H Sendai, E Inoue, M Tanaka, S Suzuki, S Satoh, S Muto, T Otomo, T Nakatani, T Uchida, Noriaki ANDO, Tetsuo KOTOKU, Satoshi HIRANO, "Development of DAQ-Middleware", CHEP'09. 17th International Conference on Computing in High Energy and Nuclear Physics, 2009.03, ãƒ—ãƒ©ãƒ, ãƒã‚§ã‚³, http://www.iop.org/EJ/volume/1742-6596/2009 &ref(SI2009_Suzuki_3D1_1.pdf,[PDF]);
++Tamio Tanikawa, Ohara Ken'ichi, Hiroyuki Nakamoto , Masato Iijima, Noriaki ANDO, Takeshi SAKAMOTO, Tetsuo KOTOKU, Kotaro OHBA, Tatsuo ARAI, "Smart home for security and low power consumption based on Ubiquitous Robotics", The 6th International Conference on Ubiquitous Robots and Ambient Intelligence (URAI 2009), pp.185-188, 2009.10, éŸ“å›½ã€å…‰å·ž &ref(URAI2009_tanikawa.pdf,[PDF]);
 
-** ‘“àŠw‰ï
+** å›½å†…å­¦ä¼š
 
-+ˆÀ“¡ Œcº, ´… ¹K, Œ´ Œ÷, ”ä—¯ì ”Ž‹v, "RTƒRƒ“ƒ|[ƒlƒ“ƒg‚Ì•¡‡‰»‚Æ‚»‚Ì•ª—Þ‚¨‚æ‚Ñ\’zƒc[ƒ‹‚É‚Â‚¢‚Ä", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2009, p.2A2-D01, 2009.05, •Ÿ‰ª &ref(ROBOMEC09_Ando_Composite_2A2-D01.pdf,[PDF]);
-+ˆÀ“¡ Œcº, _“¿ “O—Y, ²X–Ø ‹B, ‹´–{ G‹I, "‘gž‚ÝLinux‚Ì‚½‚ß‚ÌRTƒ~ƒhƒ‹ƒEƒGƒA‚ÆŠJ”­ŠÂ‹«", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2009, p.2A1-C13, 2009.05, •Ÿ‰ª &ref(ROBOMEC09_Ando_EmbLinux_2A1-C13.pdf,[PDF]);
-+ˆÀ“¡ Œcº, Œ´ Œ÷, ‘åê Œõ‘¾˜Y, "ƒÊITRONƒx[ƒX‘gž‚ÝƒVƒXƒeƒ€‚Ì‚½‚ß‚ÌRTƒ~ƒhƒ‹ƒEƒGƒA", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2009, p.2A1-C14, 2009.05, •Ÿ‰ª &ref(ROBOMEC09_Ando_TOPPERS_2A1-C14.pdf,[PDF]);
-+Œ´ Œ÷, ˆÀ“¡ Œcº, _“¿ “O—Y, ––œA ®Žm, "Œy—ÊCORBA RtORB ‚É‚æ‚éOpenRTM ‚ÌŽÀ‘•‚Æ•]‰¿", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2009, p.2A2-D05, 2009.05, •Ÿ‰ª &ref(ROBOMEC09_Hara_RtORB_2A2-D05.pdf,[PDF]);
-+ˆÀ“¡ Œcº, ŒIŒ´ áÁ“ñ, _“¿ “O—Y, ´… ¹K, ’‡‹g ˆê’j, ˆÀ –FŽŸ, "ƒRƒ“ƒ|[ƒlƒ“ƒgŠÔ‚Ì‘½—l‚Èƒ|ƒŠƒV‚ÉŠî‚Ã‚­‘—ŽóM•ûŽ®‚ðŽÀŒ»‚·‚éƒf[ƒ^ƒ|[ƒg‚ÌŽÀ‘•", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2009 (SI2009), No.3D3_6, pp.1485-1486, 2009.05, “Œ‹ž &ref(SI2009_Ando_3D3_6.pdf,[PDF]);
-+ŠÖŒû ®‘å, Geoffrey Biggs, —é–Ø Œ\‰î, ˆÀ“¡ Œcº, Mathias Clerc, ’Jì –¯¶, ¬“‡ ˆê_, _“¿ “O—Y, "RoLo‚É€‹’‚µ‚½‚q‚sƒRƒ“ƒ|[ƒlƒ“ƒg‚É‚æ‚éˆÚ“®ƒƒ{ƒbƒgƒVƒXƒeƒ€", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2009 (SI2009), No.1B4_2, pp.91-93, 2009.05, “Œ‹ž &ref(SI2009_Sekiguchi_1B4_2.pdf,[PDF]);
-+—é–Ø Œ\‰î, ’Jì –¯¶, •y‘ò“N—Y, ˆÀ“¡ Œcº, _“¿ “O—Y, "RTƒ~ƒhƒ‹ƒEƒFƒA‚É‚æ‚éƒAƒNƒeƒBƒuƒLƒƒƒXƒ^‚ÌƒRƒ“ƒ|[ƒlƒ“ƒg‰»", Œv‘ªŽ©“®§ŒäŠw‰ï ƒVƒXƒeƒ€ƒCƒ“ƒeƒOƒŒ[ƒVƒ‡ƒ“•”–å u‰‰‰ï 2009 (SI2009), No.3D1_1, pp.1437-1438, 2009.05, “Œ‹ž &ref(SI2009_Suzuki_3D1_1.pdf,[PDF]);
++å®‰è—¤ æ…¶æ˜­, æ¸…æ°´ æ˜Œå¹¸, åŽŸ åŠŸ, æ¯”ç•™å· åšä¹…, "RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã®è¤‡åˆåŒ–ã¨ãã®åˆ†é¡žãŠã‚ˆã³æ§‹ç¯‰ãƒ„ãƒ¼ãƒ«ã«ã¤ã„ã¦", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2009, p.2A2-D01, 2009.05, ç¦å²¡ &ref(ROBOMEC09_Ando_Composite_2A2-D01.pdf,[PDF]);
++å®‰è—¤ æ…¶æ˜­, ç¥žå¾³ å¾¹é›„, ä½ã€…æœ¨ æ¯…, æ©‹æœ¬ ç§€ç´€, "çµ„è¾¼ã¿Linuxã®ãŸã‚ã®RTãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢ã¨é–‹ç™ºç’°å¢ƒ", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2009, p.2A1-C13, 2009.05, ç¦å²¡ &ref(ROBOMEC09_Ando_EmbLinux_2A1-C13.pdf,[PDF]);
++å®‰è—¤ æ…¶æ˜­, åŽŸ åŠŸ, å¤§å ´ å…‰å¤ªéƒŽ, "Î¼ITRONãƒ™ãƒ¼ã‚¹çµ„è¾¼ã¿ã‚·ã‚¹ãƒ†ãƒ ã®ãŸã‚ã®RTãƒŸãƒ‰ãƒ«ã‚¦ã‚¨ã‚¢", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2009, p.2A1-C14, 2009.05, ç¦å²¡ &ref(ROBOMEC09_Ando_TOPPERS_2A1-C14.pdf,[PDF]);
++åŽŸ åŠŸ, å®‰è—¤ æ…¶æ˜­, ç¥žå¾³ å¾¹é›„, æœ«å»£ å°šå£«, "è»½é‡CORBA RtORB ã«ã‚ˆã‚‹OpenRTM ã®å®Ÿè£…ã¨è©•ä¾¡", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2009, p.2A2-D05, 2009.05, ç¦å²¡ &ref(ROBOMEC09_Hara_RtORB_2A2-D05.pdf,[PDF]);
++å®‰è—¤ æ…¶æ˜­, æ —åŽŸ çœžäºŒ, ç¥žå¾³ å¾¹é›„, æ¸…æ°´ æ˜Œå¹¸, ä»²å‰ ä¸€ç”·, å®‰ èŠ³æ¬¡, "ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆé–“ã®å¤šæ§˜ãªãƒãƒªã‚·ã«åŸºã¥ãé€å—ä¿¡æ–¹å¼ã‚’å®Ÿç¾ã™ã‚‹ãƒ‡ãƒ¼ã‚¿ãƒãƒ¼ãƒˆã®å®Ÿè£…", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2009 (SI2009), No.3D3_6, pp.1485-1486, 2009.05, æ±äº¬ &ref(SI2009_Ando_3D3_6.pdf,[PDF]);
++é–¢å£ å°šå¤§, Geoffrey Biggs, éˆ´æœ¨ åœ­ä»‹, å®‰è—¤ æ…¶æ˜­, Mathias Clerc, è°·å· æ°‘ç”Ÿ, å°å³¶ ä¸€æµ©, ç¥žå¾³ å¾¹é›„, "RoLoã«æº–æ‹ ã—ãŸï¼²ï¼´ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã«ã‚ˆã‚‹ç§»å‹•ãƒ­ãƒœãƒƒãƒˆã‚·ã‚¹ãƒ†ãƒ ", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2009 (SI2009), No.1B4_2, pp.91-93, 2009.05, æ±äº¬ &ref(SI2009_Sekiguchi_1B4_2.pdf,[PDF]);
++éˆ´æœ¨ åœ­ä»‹, è°·å· æ°‘ç”Ÿ, å†¨æ²¢å“²é›„, å®‰è—¤ æ…¶æ˜­, ç¥žå¾³ å¾¹é›„, "RTãƒŸãƒ‰ãƒ«ã‚¦ã‚§ã‚¢ã«ã‚ˆã‚‹ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã‚­ãƒ£ã‚¹ã‚¿ã®ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆåŒ–", è¨ˆæ¸¬è‡ªå‹•åˆ¶å¾¡å­¦ä¼š ã‚·ã‚¹ãƒ†ãƒ ã‚¤ãƒ³ãƒ†ã‚°ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³éƒ¨é–€ è¬›æ¼”ä¼š 2009 (SI2009), No.3D1_1, pp.1437-1438, 2009.05, æ±äº¬ &ref(SI2009_Suzuki_3D1_1.pdf,[PDF]);
 
-*˜_•¶ŒöŠJ‹K’è‚É‚Â‚¢‚Ä 
-–{ƒy[ƒW‚Å‚ÍAŠeŠw‰ï‚Ì˜_•¶ŒöŠJ‹K’è‚É]‚Á‚Ä‰Â”\‚ÈŒÀ‚è˜_•¶Œ´e‚ÌŒöŠJ‚ðs‚Á‚Ä‚¨‚è‚Ü‚·B
+*è«–æ–‡å…¬é–‹è¦å®šã«ã¤ã„ã¦ 
+æœ¬ãƒšãƒ¼ã‚¸ã§ã¯ã€å„å­¦ä¼šã®è«–æ–‡å…¬é–‹è¦å®šã«å¾“ã£ã¦å¯èƒ½ãªé™ã‚Šè«–æ–‡åŽŸç¨¿ã®å…¬é–‹ã‚’è¡Œã£ã¦ãŠã‚Šã¾ã™ã€‚
 
--[[ƒƒ{ƒbƒgŠw‰ï:http://www.rsj.or.jp/JRSJ/kaitei_20060215.html]]
---–{l‚ªŽ©g‚¨‚æ‚ÑŠ‘®‹@ŠÖ‚ÌWebƒy[ƒW‚ÅŒöŠJ‚·‚éŒÀ‚è‹–‘ø‚³‚ê‚éB
--[[“ú–{‹@ŠBŠw‰ï:http://www.jsme.or.jp/publish/yoko/yokob_t.htm]]
---–{l‚ªŽ©g‚¨‚æ‚ÑŠ‘®‹@ŠÖ‚ÌWebƒy[ƒW‚ÅŒöŠJ‚·‚éŒÀ‚è‹–‘ø‚³‚ê‚éB
+-[[ãƒ­ãƒœãƒƒãƒˆå­¦ä¼š:http://www.rsj.or.jp/JRSJ/kaitei_20060215.html]]
+--æœ¬äººãŒè‡ªèº«ãŠã‚ˆã³æ‰€å±žæ©Ÿé–¢ã®Webãƒšãƒ¼ã‚¸ã§å…¬é–‹ã™ã‚‹é™ã‚Šè¨±è«¾ã•ã‚Œã‚‹ã€‚
+-[[æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š:http://www.jsme.or.jp/publish/yoko/yokob_t.htm]]
+--æœ¬äººãŒè‡ªèº«ãŠã‚ˆã³æ‰€å±žæ©Ÿé–¢ã®Webãƒšãƒ¼ã‚¸ã§å…¬é–‹ã™ã‚‹é™ã‚Šè¨±è«¾ã•ã‚Œã‚‹ã€‚

--- a/Research_and_Development/Publication/paper_2010_ja.txt
+++ b/Research_and_Development/Publication/paper_2010_ja.txt
@@ -1,24 +1,24 @@
-// Title: ˜_•¶ (2010”N)
+// Title: è«–æ–‡ (2010å¹´)
 #contents
 
-** ˜_•¶Ž
-+‰i“c ˜a”V, ˜e“c —Dm, ŽR–ì•Ó ‰ÄŽ÷, ˆÀ“¡ Œcº, "OpenRTM-aist‚É‚æ‚é¶ŠˆŽx‰‡ƒƒ{ƒbƒg‚Ì‚½‚ß‚Ìƒƒ{ƒbƒgƒA[ƒ€‚¨‚æ‚Ñƒ}ƒ“ƒ}ƒVƒ“ƒCƒ“ƒ^ƒtƒF[ƒX‚Ì‚q‚sƒRƒ“ƒ|[ƒlƒ“ƒgŠJ”­", “ú–{‹@ŠBŠw‰ï˜_•¶W (C•Ò), Vol.76, No.766, pp.27-34, 2010.06
+** è«–æ–‡èªŒ
++æ°¸ç”° å’Œä¹‹, è„‡ç”° å„ªä», å±±é‡Žè¾º å¤æ¨¹, å®‰è—¤ æ…¶æ˜­, "OpenRTM-aistã«ã‚ˆã‚‹ç”Ÿæ´»æ”¯æ´ãƒ­ãƒœãƒƒãƒˆã®ãŸã‚ã®ãƒ­ãƒœãƒƒãƒˆã‚¢ãƒ¼ãƒ ãŠã‚ˆã³ãƒžãƒ³ãƒžã‚·ãƒ³ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã®ï¼²ï¼´ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆé–‹ç™º", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼šè«–æ–‡é›† (Cç·¨), Vol.76, No.766, pp.27-34, 2010.06
 
-** ‘“àŠw‰ï
+** å›½å†…å­¦ä¼š
 
-+ˆÀ“¡ Œcº, ŒIŒ´ áÁ“ñ, ƒrƒOƒY ƒWƒFƒt, _“¿ “O—Y, "OpenRTM-aist-1.0 ‚É‚¨‚¯‚éRTƒRƒ“ƒ|[ƒlƒ“ƒgƒ}ƒl[ƒWƒƒ", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2010, p.2A1-G02, 2010.06, –kŠC“¹, ˆ®ìŽs &ref(ROBOMEC2010_Ando_rtcd_2A1-G02.pdf,[PDF]);
-+ˆÀ“¡ Œcº, ŒIŒ´ áÁ“ñ, •ÐŒ© „l, â–{ •Žu, "OpenRTM-aist-1.0 ‚É‚¨‚¯‚éV‚µ‚¢ƒT[ƒrƒXƒ|[ƒg‚ÌŽÀ‘•", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2010, p.2A1-G01, 2010.06, –kŠC“¹, ˆ®ìŽs &ref(ROBOMEC2010_Ando_svcport_2A1-G01.pdf,[PDF]);
-+’£ •q_, —› Œ«“¿, ‹à ÃÉ, ŒIŒ´ áÁ“ñ, ƒrƒOƒY ƒWƒFƒt, ˆÀ“¡ Œcº, "ARToolKit ‚ð—p‚¢‚½Šg’£Œ»ŽÀƒVƒXƒeƒ€‚Ì‚½‚ß‚ÌRTƒRƒ“ƒ|[ƒlƒ“ƒg", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2010, p.2P1-B03, 2010.06, –kŠC“¹, ˆ®ìŽs &ref(ROBOMEC2010_Chang_2P1-B03.pdf,[PDF]);
-+Geoffrey BIGGS, Noriaki ANDO, Tetsuo KOTOKU, "rtcshell: Command-line tools for OpenRTM-aist", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2010, p.2P1-A23, 2010.06, –kŠC“¹, ˆ®ìŽs &ref(ROBOMEC2010_Geoff_2P1-A23.pdf,[PDF]);
-+—› Œ«“¿, ‹à ÃÉ, ’£ •q_, ˆÀ“¡ Œcº, "OpenRTM-aist ‚ÆTECS (TOPPERS Embedded Component System) ‚Ì˜AŒg‚ÉŠÖ‚·‚élŽ@", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2010, p.2P1-B04, 2010.06, –kŠC“¹, ˆ®ìŽs &ref(ROBOMEC2010_Kim_2P1-B04.pdf,[PDF]);
-+¬“‡ ˆê_, ˆÀ“¡ Œcº, ’Jì –¯¶, _“¿ “O—Y, "ƒI[ƒvƒ“ƒ\[ƒXƒn[ƒhƒEƒFƒA‚É‚æ‚éW‡’mƒZƒ“ƒTƒlƒbƒgƒ[ƒN‚Ì\’z‚ÆƒfƒoƒCƒXŠJ”­", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2010, p.2P1-B05, 2010.06, –kŠC“¹, ˆ®ìŽs &ref(ROBOMEC2010_Kojima_2P1-B05.pdf,[PDF]);
-+ŒIŒ´ áÁ“ñ, •ÐŒ© „l, ”’“c _º, ‹{–{ °”ü, â–{ •Žu, ˆÀ“¡ Œcº, "OpenRTM-aist-1.0 ‚É‚¨‚¯‚éV‚µ‚¢ƒf[ƒ^ƒ|[ƒg‚ÌŽÀ‘•", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2010, p.2A1-G03, 2010.06, –kŠC“¹, ˆ®ìŽs &ref(ROBOMEC2010_Kurihara_2A1-G03.pdf,[PDF]);
-+‹à ÃÉ, —› Œ«“¿, —« œ¨‘z, ŒIŒ´ áÁ“ñ, ƒrƒOƒY ƒWƒFƒt, ˆÀ“¡ Œcº, "OpenCV 2.0 ‚ð—p‚¢‚½‰f‘œˆ—ƒVƒXƒeƒ€‚Ì‚½‚ß‚ÌRTƒRƒ“ƒ|[ƒlƒ“ƒgŒQ", “ú–{‹@ŠBŠw‰ï ƒƒ{ƒeƒBƒNƒXEƒƒJƒgƒƒjƒNƒXu‰‰‰ï2010, p.2P1-A21, 2010.06, –kŠC“¹, ˆ®ìŽs &ref(ROBOMEC2010_Lee_OpenCV_2P1-A21.pdf,[PDF]);
++å®‰è—¤ æ…¶æ˜­, æ —åŽŸ çœžäºŒ, ãƒ“ã‚°ã‚º ã‚¸ã‚§ãƒ•, ç¥žå¾³ å¾¹é›„, "OpenRTM-aist-1.0 ã«ãŠã‘ã‚‹RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆãƒžãƒãƒ¼ã‚¸ãƒ£", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2010, p.2A1-G02, 2010.06, åŒ—æµ·é“, æ—­å·å¸‚ &ref(ROBOMEC2010_Ando_rtcd_2A1-G02.pdf,[PDF]);
++å®‰è—¤ æ…¶æ˜­, æ —åŽŸ çœžäºŒ, ç‰‡è¦‹ å‰›äºº, å‚æœ¬ æ­¦å¿—, "OpenRTM-aist-1.0 ã«ãŠã‘ã‚‹æ–°ã—ã„ã‚µãƒ¼ãƒ“ã‚¹ãƒãƒ¼ãƒˆã®å®Ÿè£…", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2010, p.2A1-G01, 2010.06, åŒ—æµ·é“, æ—­å·å¸‚ &ref(ROBOMEC2010_Ando_svcport_2A1-G01.pdf,[PDF]);
++å¼µ æ•æµ©, æŽ è³¢å¾³, é‡‘ æ¹˜å®°, æ —åŽŸ çœžäºŒ, ãƒ“ã‚°ã‚º ã‚¸ã‚§ãƒ•, å®‰è—¤ æ…¶æ˜­, "ARToolKit ã‚’ç”¨ã„ãŸæ‹¡å¼µç¾å®Ÿã‚·ã‚¹ãƒ†ãƒ ã®ãŸã‚ã®RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆ", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2010, p.2P1-B03, 2010.06, åŒ—æµ·é“, æ—­å·å¸‚ &ref(ROBOMEC2010_Chang_2P1-B03.pdf,[PDF]);
++Geoffrey BIGGS, Noriaki ANDO, Tetsuo KOTOKU, "rtcshell: Command-line tools for OpenRTM-aist", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2010, p.2P1-A23, 2010.06, åŒ—æµ·é“, æ—­å·å¸‚ &ref(ROBOMEC2010_Geoff_2P1-A23.pdf,[PDF]);
++æŽ è³¢å¾³, é‡‘ æ¹˜å®°, å¼µ æ•æµ©, å®‰è—¤ æ…¶æ˜­, "OpenRTM-aist ã¨TECS (TOPPERS Embedded Component System) ã®é€£æºã«é–¢ã™ã‚‹è€ƒå¯Ÿ", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2010, p.2P1-B04, 2010.06, åŒ—æµ·é“, æ—­å·å¸‚ &ref(ROBOMEC2010_Kim_2P1-B04.pdf,[PDF]);
++å°å³¶ ä¸€æµ©, å®‰è—¤ æ…¶æ˜­, è°·å· æ°‘ç”Ÿ, ç¥žå¾³ å¾¹é›„, "ã‚ªãƒ¼ãƒ—ãƒ³ã‚½ãƒ¼ã‚¹ãƒãƒ¼ãƒ‰ã‚¦ã‚§ã‚¢ã«ã‚ˆã‚‹é›†åˆçŸ¥ã‚»ãƒ³ã‚µãƒãƒƒãƒˆãƒ¯ãƒ¼ã‚¯ã®æ§‹ç¯‰ã¨ãƒ‡ãƒã‚¤ã‚¹é–‹ç™º", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2010, p.2P1-B05, 2010.06, åŒ—æµ·é“, æ—­å·å¸‚ &ref(ROBOMEC2010_Kojima_2P1-B05.pdf,[PDF]);
++æ —åŽŸ çœžäºŒ, ç‰‡è¦‹ å‰›äºº, ç™½ç”° æµ©æ˜­, å®®æœ¬ æ™´ç¾Ž, å‚æœ¬ æ­¦å¿—, å®‰è—¤ æ…¶æ˜­, "OpenRTM-aist-1.0 ã«ãŠã‘ã‚‹æ–°ã—ã„ãƒ‡ãƒ¼ã‚¿ãƒãƒ¼ãƒˆã®å®Ÿè£…", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2010, p.2A1-G03, 2010.06, åŒ—æµ·é“, æ—­å·å¸‚ &ref(ROBOMEC2010_Kurihara_2A1-G03.pdf,[PDF]);
++é‡‘ æ¹˜å®°, æŽ è³¢å¾³, åŠ‰ æƒ æƒ³, æ —åŽŸ çœžäºŒ, ãƒ“ã‚°ã‚º ã‚¸ã‚§ãƒ•, å®‰è—¤ æ…¶æ˜­, "OpenCV 2.0 ã‚’ç”¨ã„ãŸæ˜ åƒå‡¦ç†ã‚·ã‚¹ãƒ†ãƒ ã®ãŸã‚ã®RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆç¾¤", æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š ãƒ­ãƒœãƒ†ã‚£ã‚¯ã‚¹ãƒ»ãƒ¡ã‚«ãƒˆãƒ­ãƒ‹ã‚¯ã‚¹è¬›æ¼”ä¼š2010, p.2P1-A21, 2010.06, åŒ—æµ·é“, æ—­å·å¸‚ &ref(ROBOMEC2010_Lee_OpenCV_2P1-A21.pdf,[PDF]);
 
-**˜_•¶ŒöŠJ‹K’è‚É‚Â‚¢‚Ä 
-–{ƒy[ƒW‚Å‚ÍAŠeŠw‰ï‚Ì˜_•¶ŒöŠJ‹K’è‚É]‚Á‚Ä‰Â”\‚ÈŒÀ‚è˜_•¶Œ´e‚ÌŒöŠJ‚ðs‚Á‚Ä‚¨‚è‚Ü‚·B
+**è«–æ–‡å…¬é–‹è¦å®šã«ã¤ã„ã¦ 
+æœ¬ãƒšãƒ¼ã‚¸ã§ã¯ã€å„å­¦ä¼šã®è«–æ–‡å…¬é–‹è¦å®šã«å¾“ã£ã¦å¯èƒ½ãªé™ã‚Šè«–æ–‡åŽŸç¨¿ã®å…¬é–‹ã‚’è¡Œã£ã¦ãŠã‚Šã¾ã™ã€‚
 
--[[ƒƒ{ƒbƒgŠw‰ï:http://www.rsj.or.jp/JRSJ/kaitei_20060215.html]]
---–{l‚ªŽ©g‚¨‚æ‚ÑŠ‘®‹@ŠÖ‚ÌWebƒy[ƒW‚ÅŒöŠJ‚·‚éŒÀ‚è‹–‘ø‚³‚ê‚éB
--[[“ú–{‹@ŠBŠw‰ï:http://www.jsme.or.jp/publish/yoko/yokob_t.htm]]
---–{l‚ªŽ©g‚¨‚æ‚ÑŠ‘®‹@ŠÖ‚ÌWebƒy[ƒW‚ÅŒöŠJ‚·‚éŒÀ‚è‹–‘ø‚³‚ê‚éB
+-[[ãƒ­ãƒœãƒƒãƒˆå­¦ä¼š:http://www.rsj.or.jp/JRSJ/kaitei_20060215.html]]
+--æœ¬äººãŒè‡ªèº«ãŠã‚ˆã³æ‰€å±žæ©Ÿé–¢ã®Webãƒšãƒ¼ã‚¸ã§å…¬é–‹ã™ã‚‹é™ã‚Šè¨±è«¾ã•ã‚Œã‚‹ã€‚
+-[[æ—¥æœ¬æ©Ÿæ¢°å­¦ä¼š:http://www.jsme.or.jp/publish/yoko/yokob_t.htm]]
+--æœ¬äººãŒè‡ªèº«ãŠã‚ˆã³æ‰€å±žæ©Ÿé–¢ã®Webãƒšãƒ¼ã‚¸ã§å…¬é–‹ã™ã‚‹é™ã‚Šè¨±è«¾ã•ã‚Œã‚‹ã€‚


### PR DESCRIPTION
## Description of the Change

一部のエンコーディングがShiftJISだったため、UTF-8に変更

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you check grammar?  (ex. https://www.grammarly.com/, https://www.kiji-check.com/) 
- [x] Did you check pukiwiki grammar?
- [x] Did you check Japanese-English consistency?  
