### PR TITLE
「rtshellのインストール」ページの修正

### DIFF
--- a/documents/02_installation/05_install_rtshell/01_howto_install/01_howto_install_en.txt
+++ b/documents/02_installation/05_install_rtshell/01_howto_install/01_howto_install_en.txt
@@ -2,27 +2,25 @@
 
 #contents
 
-To install rtshell, you need to install OpenRTM-aist-Python because rtshell is a Python program. Therefore, to use rtshell, it is required to install OpenRTM-aist-Python and Python execution environment before installing rtshell. (The bulk installation script for Linux installs Python in the script, but in the case of Windows the msi install needs to be installed beforehand. The supported Python version is 3.7, 3.6, 2.7.)
+To install rtshell, you need to install OpenRTM-aist-Python because rtshell is a Python program. Therefore, to use rtshell, it is required to install OpenRTM-aist-Python and Python execution environment before installing rtshell. (The bulk installation script for Linux installs Python in the script, but in the case of Windows the msi install needs to be installed beforehand. The supported Python version is 3.7, 3.6, 3.5, 2.7.)
 
 ** Installation on Windows
 Please install OpenRTM-aist by msi installer. Please refer to the following page for the procedure. &br;
 [[OpenRTM-aist 1.2 installation (Windows, using msi installer)>//node/6652]]
 
 ** Installation on Linux environment
-Use [[bulk installation script>//node/6990]] to install OpenRTM-aist-Python and rtshell with using "-l python" and "-l rtshell" options and then execute rtshell_post_install. 
+Use [[bulk installation script>//node/6990]] to install rtshell with using "-l c++", "-l python" and "-l rtshell" options and then execute rtshell_post_install.
 
 *** Ubuntu 18.04 case:
 Move to the directory where the bulk installation script is downloaded and type in:
- $ sudo sh pkg_install_ubuntu.sh -l python --yes
- $ sudo sh pkg_install_ubuntu.sh -l rtshell --yes
+ $ sudo sh pkg_install_ubuntu.sh -l c++ -l python -l rtshell --yes
  $ sudo rtshell_post_install
 
 Close the terminal once.
 
 *** Raspbian case:
 Move to the directory where the bulk installation script is downloaded and type in:
- $ sudo sh pkg_install_raspbian.sh -l python --yes
- $ sudo sh pkg_install_raspbian.sh -l rtshell --yes
+ $ sudo sh pkg_install_raspbian.sh -l c++ -l python -l rtshell --yes
  $ sudo rtshell_post_install
 
 Close the terminal once.

--- a/documents/02_installation/05_install_rtshell/01_howto_install/01_howto_install_ja.txt
+++ b/documents/02_installation/05_install_rtshell/01_howto_install/01_howto_install_ja.txt
@@ -2,28 +2,26 @@
 
 #contents
 
-rtshellのインストールにはrtshellがPythonのプログラムであるため、OpenRTM-aist-Pythonのインストールが必要になります。よって、インストールはOpenRTM-aist-Pythonとrtshellのインストール、およびPythonの実行環境のインストールが必要になる場合があります。(Linuxの一括インストールはそのスクリプトの中でPythonのインストールを行いますが、Windowsのmsiのケースは前もってインストールをする必要があります。なお対応しているPythonのバージョンは3.7、3.6、2.7です。)
+rtshellのインストールにはrtshellがPythonのプログラムであるため、OpenRTM-aist-Pythonのインストールが必要になります。よって、インストールはOpenRTM-aist-Pythonとrtshellのインストール、およびPythonの実行環境のインストールが必要になる場合があります。(Linuxの一括インストールはそのスクリプトの中でPythonのインストールを行いますが、Windowsのmsiのケースは前もってインストールをする必要があります。なお対応しているPythonのバージョンは3.7、3.6、3.5、2.7です。)
 
 ** Windowsへのインストール
 msiインストーラーによるOpenRTM-aistをインストールしてください。手順については下記のページを参照してください。&br;
 [[OpenRTM-aist 1.2系のインストール(Windows、msiインストーラー使用):/ja/node/6652]]
 
 ** Linux環境へのインストール
-[[一括インストールスクリプト>//node/6345]]を用いて、"-l python"と"-l rtshell"オプションでOpenRTM-aist-Pythonとrtshellをインストールをした後にrtshell_post_installを実行してください。
+[[一括インストールスクリプト>//node/6345]]を用いて、"-l c++"と"-l python"と"-l rtshell"オプションでrtshellをインストールをした後にrtshell_post_installを実行してください。
 
 *** Ubuntu 18.04の場合:
 一括インストールスクリプトをダウンロードしたディレクトリに移動し、以下のように入力します。
 //英語版はnode/6990
- $ sudo sh pkg_install_ubuntu.sh -l python --yes
- $ sudo sh pkg_install_ubuntu.sh -l rtshell --yes
+ $ sudo sh pkg_install_ubuntu.sh -l c++ -l python -l rtshell --yes
  $ sudo rtshell_post_install
 
 実行を修了したら、一度ターミナルを閉じてくださ。
 
 *** Raspbianの場合
 一括インストールスクリプトをダウンロードしたディレクトリに移動し、以下のように入力します。
- $ sudo sh pkg_install_raspbian.sh -l python --yes
- $ sudo sh pkg_install_raspbian.sh -l rtshell --yes
+ $ sudo sh pkg_install_raspbian.sh -l c++ -l python -l rtshell --yes
  $ sudo rtshell_post_install
 
 なおRaspbianの環境では現状問題が報告されており下記の方法で対処してください。

--- a/documents/02_installation/05_install_rtshell/03_check_linux/03_check_linux_en.txt
+++ b/documents/02_installation/05_install_rtshell/03_check_linux/03_check_linux_en.txt
@@ -19,11 +19,15 @@ The samples are under /usr/share/openrtm-1.2/components/python/SimpleIO, and the
 
 *** Start name server
 - Start the name server. It can be started with the following command.
- $ sudo python /user/lib/{python2.7|python3.6|python3.7}/dist-packages/OpenRTM_aist/utils/rtm-naming/rtm-naming.py
+ $ rtm-naming
+- In the environment where OpenRTM-aist(C++) is not installed, it is prepared so that it can be started by the following script.
+ $ python /usr/lib/python2.7/dist-packages/OpenRTM_aist/utils/rtm-naming/rtm-naming.py
+       or
+ $ python3 /usr/lib/python3/dist-packages/OpenRTM_aist/utils/rtm-naming/rtm-naming.py
  
-  Here, {Python2.7|python3.6|python3.7} changes depending on the version of Python that was installed in the Linux environment. 
-  If Python 2.7 was installed with OpenRTM-aist-Python, it is "Python2.7". (The default for Ubuntu 18.04 is Python 2.7. However the 
-  version of Python is now "End of Support", then it might be changed.) 
+Here, {Python2.7|python3} changes depending on the version of Python that was installed in the Linux environment.
+If Python 2.7 was installed with OpenRTM-aist-Python, it is "Python2.7".  &br;
+(The default for Ubuntu 18.04 is Python 2.7. However the version of Python is now "End of Support", then it might be changed.)
 
 The following screen will be displayed.
 #ref(startnameservice002.png, center)

--- a/documents/02_installation/05_install_rtshell/03_check_linux/03_check_linux_ja.txt
+++ b/documents/02_installation/05_install_rtshell/03_check_linux/03_check_linux_ja.txt
@@ -18,8 +18,12 @@ RTコンポーネントConsoleIn、ConsoleOutからなるサンプルセット�
 
 *** ネームサーバーの起動
 - ネームサーバーを起動します。以下のコマンドで起動ができます。
- $ sudo python /user/lib/{python2.7|python3.6|python3.7}/dist-packages/OpenRTM_aist/utils/rtm-naming/rtm-naming.py
-ここで{Python2.7|python3.6|python3.7}は、Python版のOpenRTM-aistをインストールした時のLinux環境でインストールしてあったPythonのバージョンによって変わり、Python 2.7がインストールされていた場合は"Python2.7"です。(Ubuntu18.04のデフォルトはPython2.7です。)
+ $ rtm-naming
+OpenRTM-aist(C++)をインストールしていない環境では、下記スクリプトで起動できるように用意しています。
+ $ python /usr/lib/python2.7/dist-packages/OpenRTM_aist/utils/rtm-naming/rtm-naming.py
+       or
+ $ python3 /usr/lib/python3/dist-packages/OpenRTM_aist/utils/rtm-naming/rtm-naming.py
+ここで{Python2.7|python3}は、Python版のOpenRTM-aistをインストールした時のLinux環境でインストールしてあったPythonのバージョンによって変わり、Python 2.7がインストールされていた場合は"Python2.7"です。(Ubuntu18.04のデフォルトはPython2.7です。)
 
 以下のような画面が表示されます。
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #255 

## Description of the Change
- 対応しているPythonバージョン番号で、Ubuntu16.04のデフォルトバージョンである3.5が抜けていたので追加した
- Linux環境での動作確認時、ネームサーバ起動コマンドは rtm-naming を基本とした
- これに伴い、一括インストールスクリプトのオプションに「-l c++」を追加した
- OpenRTM-aist(C++)をインストールしていない環境では rtm-naming.py にてネームサーバ起動が可能である旨の説明とした
- rtm-naming.pyのフルパスが間違っていたので訂正し、sudoは不要なので外した


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you check grammar?  (ex. https://www.grammarly.com/, https://www.kiji-check.com/) 
- [x] Did you check pukiwiki grammar?
- [x] Did you check Japanese-English consistency?  
