### PR TITLE
1.2.2リリース用JavaとOpenRTPダウンロードページの追加

### DIFF
--- a/download/02_openrtm-aist-java/01_openrtm-aist-java_1_2_2_release/01_openrtm-aist-java_1_2_2_release_en.txt
+++ b/download/02_openrtm-aist-java/01_openrtm-aist-java_1_2_2_release/01_openrtm-aist-java_1_2_2_release_en.txt
@@ -13,7 +13,7 @@ The msi file is 800MB in size. Use a high-speed line (50Mbps or more) to downloa
 
 **** For 64bit
 
-| LEFT:300 | LEFT | LEFT:120 |c
+| LEFT:300 | LEFT:240 | LEFT:120 |c
 | Windows Installer &br; (including OpenRTM-aist, C++, Python, &br; Java version and OpenRTP, &br; rtshell (4.2.2)) &br; (Visual Studio 2012, 2013, &br; 2015, 2017, 2019) | [[OpenRTM-aist-1.2.2-RELEASE_x86_64.msi:https://github.com/OpenRTM/OpenRTM-aist/releases/download/v1.2.2/OpenRTM-aist-1.2.2-RELEASE_x86_64.msi]] &br; MD5:0ef7130c2568713cce4054d0b7975677 | 2020/08/26 |
 |Python-3.6|[[python-3.6.8-amd64.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8-amd64.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.7|[[python-3.7.9-amd64.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9-amd64.exe]]|[[python.org:https://www.python.org]]|
@@ -26,7 +26,7 @@ The msi file is 800MB in size. Use a high-speed line (50Mbps or more) to downloa
 
 **** For 32bit
 
-| LEFT:300 | LEFT | LEFT:120 |c
+| LEFT:300 | LEFT:240 | LEFT:120 |c
 |Installer for Windows&br; (OpenRTM-aist、C++、Python、&br;Java version, and OpenRTP、&br;including rtshell(4.2.2))&br;(Visual Studio 2012、2013、&br;2015、2017、2019)|[[OpenRTM-aist-1.2.2-RELEASE_x86.msi:https://github.com/OpenRTM/OpenRTM-aist/releases/download/v1.2.2/OpenRTM-aist-1.2.2-RELEASE_x86.msi]] &br;MD5:5cb7243ff642bbbd40463b95c2308e4a | 2020/08/26 |
 |Python-3.6|[[python-3.6.8.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.7|[[python-3.7.9.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9.exe]]|[[python.org:https://www.python.org]]|

--- a/download/02_openrtm-aist-java/01_openrtm-aist-java_1_2_2_release/01_openrtm-aist-java_1_2_2_release_ja.txt
+++ b/download/02_openrtm-aist-java/01_openrtm-aist-java_1_2_2_release/01_openrtm-aist-java_1_2_2_release_ja.txt
@@ -12,7 +12,7 @@ msiファイルは800MBのサイズがあります。ダウンロードを数分
 
 **** 64bit用
 
-|LEFT:300|LEFT|LEFT:120|c
+|LEFT:300|LEFT:240|LEFT:120|c
 |Windows用インストーラー&br; (OpenRTM-aist、C++、Python、&br;Java版、および OpenRTP、&br; rtshell(4.2.2)含む)&br;(Visual Studio 2012、2013、&br; 2015、2017、2019 共通)|[[OpenRTM-aist-1.2.2-RELEASE_x86_64.msi:https://github.com/OpenRTM/OpenRTM-aist/releases/download/v1.2.2/OpenRTM-aist-1.2.2-RELEASE_x86_64.msi]] &br;MD5:0ef7130c2568713cce4054d0b7975677 | 2020/08/26 |
 |Python-3.6|[[python-3.6.8-amd64.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8-amd64.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.7|[[python-3.7.9-amd64.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9-amd64.exe]]|[[python.org:https://www.python.org]]|
@@ -25,7 +25,7 @@ msiファイルは800MBのサイズがあります。ダウンロードを数分
 
 **** 32bit用
 
-|LEFT:300|LEFT|LEFT:120|c
+|LEFT:300|LEFT:240|LEFT:120|c
 |Windows用インストーラー&br; (OpenRTM-aist、C++、Python、&br;Java版、およびOpenRTP、&br;rtshell(4.2.2)含む)&br;(Visual Studio 2012、2013、&br;2015、2017、2019共通)|[[OpenRTM-aist-1.2.2-RELEASE_x86.msi:https://github.com/OpenRTM/OpenRTM-aist/releases/download/v1.2.2/OpenRTM-aist-1.2.2-RELEASE_x86.msi]] &br;MD5:5cb7243ff642bbbd40463b95c2308e4a | 2020/08/26 |
 |Python-3.6|[[python-3.6.8.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.7|[[python-3.7.9.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9.exe]]|[[python.org:https://www.python.org]]|

--- a/download/04_tools/01_openrtp_1_2_2/01_openrtp_1_2_2_en.txt
+++ b/download/04_tools/01_openrtp_1_2_2/01_openrtp_1_2_2_en.txt
@@ -14,7 +14,7 @@ The msi file is 800MB in size. Use a high-speed line (50Mbps or more) to downloa
 
 **** For 64bit
 
-|LEFT:300|LEFT|LEFT:120|c
+|LEFT:300|LEFT:240|LEFT:120|c
 | Windows Installer &br; (including OpenRTM-aist, C++, Python, &br; Java version and OpenRTP, &br; rtshell (4.2.2)) &br; (Visual Studio 2012, 2013, &br; 2015, 2017, 2019) | [[OpenRTM-aist-1.2.2-RELEASE_x86_64.msi:https://github.com/OpenRTM/OpenRTM-aist/releases/download/v1.2.2/OpenRTM-aist-1.2.2-RELEASE_x86_64.msi]] &br; MD5:0ef7130c2568713cce4054d0b7975677 | 2020/08/26 |
 |Python-3.6|[[python-3.6.8-amd64.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8-amd64.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.7|[[python-3.7.9-amd64.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9-amd64.exe]]|[[python.org:https://www.python.org]]|
@@ -26,7 +26,7 @@ The msi file is 800MB in size. Use a high-speed line (50Mbps or more) to downloa
 
 **** For 32bit
 
-|LEFT:300|LEFT|LEFT:120|c
+|LEFT:300|LEFT:240|LEFT:120|c
 |Installer for Windows&br; (OpenRTM-aist、C++、Python、&br;Java version, and OpenRTP、&br;including rtshell(4.2.2))&br;(Visual Studio 2012、2013、&br;2015、2017、2019)|[[OpenRTM-aist-1.2.2-RELEASE_x86.msi:https://github.com/OpenRTM/OpenRTM-aist/releases/download/v1.2.2/OpenRTM-aist-1.2.2-RELEASE_x86.msi]] &br;MD5:5cb7243ff642bbbd40463b95c2308e4a | 2020/08/26 |
 |Python-3.6|[[python-3.6.8.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.7|[[python-3.7.9.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9.exe]]|[[python.org:https://www.python.org]]|

--- a/download/04_tools/01_openrtp_1_2_2/01_openrtp_1_2_2_ja.txt
+++ b/download/04_tools/01_openrtp_1_2_2/01_openrtp_1_2_2_ja.txt
@@ -13,7 +13,7 @@ msiファイルは800MBのサイズがあります。ダウンロードを数分
 
 **** 64bit用
 
-|LEFT:300|LEFT|LEFT:120|c
+|LEFT:300|LEFT:240|LEFT:120|c
 |Windows用インストーラー&br; (OpenRTM-aist、C++、Python、&br;Java版、および OpenRTP、&br; rtshell(4.2.2)含む)&br;(Visual Studio 2012、2013、&br; 2015、2017、2019 共通)|[[OpenRTM-aist-1.2.2-RELEASE_x86_64.msi:https://github.com/OpenRTM/OpenRTM-aist/releases/download/v1.2.2/OpenRTM-aist-1.2.2-RELEASE_x86_64.msi]] &br;MD5:0ef7130c2568713cce4054d0b7975677 | 2020/08/26 |
 |Python-3.6|[[python-3.6.8-amd64.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8-amd64.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.7|[[python-3.7.9-amd64.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9-amd64.exe]]|[[python.org:https://www.python.org]]|
@@ -26,7 +26,7 @@ msiファイルは800MBのサイズがあります。ダウンロードを数分
 
 **** 32bit用
 
-|LEFT:300|LEFT|LEFT:120|c
+|LEFT:300|LEFT:240|LEFT:120|c
 |Windows用インストーラー&br; (OpenRTM-aist、C++、Python、&br;Java版、およびOpenRTP、&br;rtshell(4.2.2)含む)&br;(Visual Studio 2012、2013、&br;2015、2017、2019共通)|[[OpenRTM-aist-1.2.2-RELEASE_x86.msi:https://github.com/OpenRTM/OpenRTM-aist/releases/download/v1.2.2/OpenRTM-aist-1.2.2-RELEASE_x86.msi]] &br;MD5:5cb7243ff642bbbd40463b95c2308e4a | 2020/08/26 |
 |Python-3.6|[[python-3.6.8.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.7|[[python-3.7.9.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9.exe]]|[[python.org:https://www.python.org]]|


### PR DESCRIPTION
link to #271 

Drupal更新に伴い、以下のファイルを更新しました

- https://openrtm.org/openrtm/ja/download/openrtm-aist-java/openrtm-aist-java_1_2_2_release
  - ->/download/02_openrtm-aist-java/01_openrtm-aist-java_1_2_2_release/01_openrtm-aist-java_1_2_2_release_ja.txt
- https://openrtm.org/openrtm/en/download/openrtm-aist-java/openrtm-aist-java_1_2_2_release
  - ->/download/02_openrtm-aist-java/01_openrtm-aist-java_1_2_2_release/01_openrtm-aist-java_1_2_2_release_en.txt
- https://openrtm.org/openrtm/ja/download/tools/openrtp_1_2_2
  - ->/download/04_tools/01_openrtp_1_2_2/01_openrtp_1_2_2_ja.txt
- https://openrtm.org/openrtm/en/download/tools/openrtp_1_2_2
  - ->/download/04_tools/01_openrtp_1_2_2/01_openrtp_1_2_2_en.txt

- [x] Did you check grammar?  (ex. https://www.grammarly.com/, https://www.kiji-check.com/) 
- [x] Did you check pukiwiki grammar?
- [x] Did you check Japanese-English consistency?  
