### PR TITLE
1.2.2リリースに伴う、クラスリファレンスの更新

### DIFF
--- a/documents/05_openrtm-aist_class_reference/05_openrtm-aist_class_reference_en.txt
+++ b/documents/05_openrtm-aist_class_reference/05_openrtm-aist_class_reference_en.txt
@@ -1,15 +1,21 @@
-﻿// Title: OpenRTM-aist class references
+// Title: OpenRTM-aist class references
 //-[[Configuration:/en/node/474]]OpenRTM-aist class references
 //-[[Detailed explanation for DataPort:/en/node/475]]
 
 #ref(reference.png,right,around,70%,url=/node/376)
-** The class reference of the latest version (1.2.1)
+** The class reference of the latest version (1.2.2)
 The class references were automatically generated from the newest source codes on the repository. There might be some inconsistencies between it and the latest release version of OpenRTM-aist.
+
+-[[C++ class reference>http://openrtm.org/doc/cxx/1.2.2/classreference_en/index.html]]
+-[[Python class reference>http://openrtm.org/doc/python/1.2.2/classreference_en/index.html]]
+-[[Java class reference>http://openrtm.org/doc/java/1.2.2/classreference_en/index.html]]
+<!--break-->
+
+** 1.2.1 class references
 
 -[[C++ class reference>http://openrtm.org/doc/cxx/1.2.1/classreference_en/index.html]]
 -[[Python class reference>http://openrtm.org/doc/python/1.2.1/classreference_en/index.html]]
 -[[Java class reference>http://openrtm.org/doc/java/1.2.1/classreference_en/index.html]]
-<!--break-->
 
 ** 1.2 IDL references
 

--- a/documents/05_openrtm-aist_class_reference/05_openrtm-aist_class_reference_ja.txt
+++ b/documents/05_openrtm-aist_class_reference/05_openrtm-aist_class_reference_ja.txt
@@ -1,15 +1,22 @@
-﻿// Title: クラスリファレンス
+// Title: クラスリファレンス
 #ref(reference.png,right,around,70%,url=/node/109)
-** 最新版(1.2.1)クラスリファレンス
+** 最新版(1.2.2)クラスリファレンス
 
 クラスリファレンスは、リポジトリ上の最新版のソースコードから自動的に生成されています。
 リリース版の機能とは一部異なっている可能性があるのでご注意ください。
+
+-[[C++クラスリファレンス>http://openrtm.org/doc/cxx/1.2.2/classreference_ja/index.html]]
+-[[Pythonクラスリファレンス>http://openrtm.org/doc/python/1.2.2/classreference_ja/index.html]]
+-[[Javaクラスリファレンス>http://openrtm.org/doc/java/1.2.2/classreference_ja/index.html]]
+
+<!--break-->
+
+** 1.2クラスリファレンス
 
 -[[C++クラスリファレンス>http://openrtm.org/doc/cxx/1.2.1/classreference_ja/index.html]]
 -[[Pythonクラスリファレンス>http://openrtm.org/doc/python/1.2.1/classreference_ja/index.html]]
 -[[Javaクラスリファレンス>http://openrtm.org/doc/java/1.2.1/classreference_ja/index.html]]
 -[[データ型解説ページ>https://nobu19800.github.io/DataTypeManual/docs/]]
-<!--break-->
 
 ** 1.2 IDLリファレンス
 


### PR DESCRIPTION
link to #280 
Drupal更新にともない、更新しました。
- クラスリファレンス
  - https://openrtm.org/openrtm/ja/doc/openrtm-aist_class_reference
    - /openrtm.org/documents/05_openrtm-aist_class_reference/05_openrtm-aist_class_reference_ja.txt 
- OpenRTM-aist class references
  - https://openrtm.org/openrtm/en/doc/openrtm-aist_class_reference
    - /openrtm.org/documents/05_openrtm-aist_class_reference/05_openrtm-aist_class_reference_en.txt 

- [x] Did you check grammar?  (ex. https://www.grammarly.com/, https://www.kiji-check.com/) 
- [x] Did you check pukiwiki grammar?
- [x] Did you check Japanese-English consistency?  
