### PR TITLE
openrtm-aist-python3-docインストール制限環境の説明追加

### DIFF
--- a/download/03_openrtm-aist-python/01_openrtm-aist-python_1_2_2_release/01_openrtm-aist-python_1_2_2_release_en.txt
+++ b/download/03_openrtm-aist-python/01_openrtm-aist-python_1_2_2_release/01_openrtm-aist-python_1_2_2_release_en.txt
@@ -61,10 +61,16 @@ Please refer to [[Bulk installation script:/ja/node/6345]] for installation meth
 
 If you have already installed 1.2.1-RELEASE, please install the package for Python3 by the following procedure.
 
-For Ubuntu / Debian
+For Ubuntu / Debian (Except Ubuntu 16.04)
 
  $ sudo apt update
  $ sudo apt install omniidl-python3 openrtm-aist-python3 openrtm-aist-python3-example openrtm-aist-python3-doc
+ 
+For Ubuntu 16.04
+
+ $ sudo apt update
+ $ sudo apt install omniidl-python3 openrtm-aist-python3 openrtm-aist-python3-example
+ 
 
 // For Fedora
 //

--- a/download/03_openrtm-aist-python/01_openrtm-aist-python_1_2_2_release/01_openrtm-aist-python_1_2_2_release_ja.txt
+++ b/download/03_openrtm-aist-python/01_openrtm-aist-python_1_2_2_release/01_openrtm-aist-python_1_2_2_release_ja.txt
@@ -68,10 +68,15 @@ msiファイルは800MBのサイズがあります。ダウンロードを数分
 
 1.2.1-RELEASEを既にインストールしている場合は、以下の手順でPython3用パッケージをインストールして下さい。
 
-Ubuntu/Debianの場合
+Ubuntu/Debianの場合（Ubuntu16.04を除く）
 
  $ sudo apt update
  $ sudo apt install omniidl-python3 openrtm-aist-python3 openrtm-aist-python3-example openrtm-aist-python3-doc
+
+Ubuntu16.04の場合
+
+ $ sudo apt update
+ $ sudo apt install omniidl-python3 openrtm-aist-python3 openrtm-aist-python3-example
 
 //Fedora　の場合
 //


### PR DESCRIPTION
link to #295 

Drupal更新に伴い、以下のファイルを更新しました
- https://openrtm.org/openrtm/ja/download/openrtm-aist-python/openrtm-aist-python_1_2_2_release
   - /download/03_openrtm-aist-python/01_openrtm-aist-python_1_2_2_release/01_openrtm-aist-python_1_2_2_release_ja.txt
- https://openrtm.org/openrtm/en/download/openrtm-aist-python/openrtm-aist-python_1_2_2_release
   - /download/03_openrtm-aist-python/01_openrtm-aist-python_1_2_2_release/01_openrtm-aist-python_1_2_2_release_en.txt

- [x] Did you check grammar?  (ex. https://www.grammarly.com/, https://www.kiji-check.com/) 
- [x] Did you check pukiwiki grammar?
- [x] Did you check Japanese-English consistency?  
