### PR TITLE
fix to link doxygen installer

### DIFF
--- a/download/01_openrtm-aist-cpp/01_openrtm-aist-cpp_1_2_2_release/01_openrtm-aist-cpp_1_2_2_release_en.txt
+++ b/download/01_openrtm-aist-cpp/01_openrtm-aist-cpp_1_2_2_release/01_openrtm-aist-cpp_1_2_2_release_en.txt
@@ -18,11 +18,13 @@ The msi file is 800MB in size. Use a high-speed line (50Mbps or more) to downloa
 |Python-3.7|[[python-3.7.9-amd64.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9-amd64.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.8|[[python-3.8.5-amd64.exe:https://www.python.org/ftp/python/3.8.5/python-3.8.5-amd64.exe]]|[[python.org:https://www.python.org]]|
 |CMake |[[cmake-3.18.1-win64-x64.msi:https://github.com/Kitware/CMake/releases/download/v3.18.1/cmake-3.18.1-win64-x64.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.19-setup.exe:http://doxygen.nl/files/doxygen-1.8.19-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 
 - &color(red){* Install Python version "3.8", "3.7", or "3.6". };
 //- &color (red){* Please delete the old rtshell beforehand. However, if the OpenRTM-aist 1.1.2 version is installed using the msi file, no action is required. };
+- The above download link may be broken when the latest version of Doxygen is released. In that case, please go to the download page of [[doxygen: http: //www.doxygen.nl/index.html]] and download and install the latest "doxygen-X.X.X-setup.exe".
+
 
 **** For 32bit
 |LEFT:300|LEFT:240|LEFT:120|c
@@ -31,10 +33,11 @@ The msi file is 800MB in size. Use a high-speed line (50Mbps or more) to downloa
 |Python-3.7|[[python-3.7.9.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.8|[[python-3.8.5.exe:https://www.python.org/ftp/python/3.8.5/python-3.8.5.exe]]|[[python.org:https://www.python.org]]|
 |CMake|[[cmake-3.18.1-win32-x86.msi:https://github.com/Kitware/CMake/releases/download/v3.18.1/cmake-3.18.1-win32-x86.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.19-setup.exe:http://doxygen.nl/files/doxygen-1.8.19-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]]  |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 
 - &color(red){※Please install one of the version of Python "3.8", "3.7" or "3.6".};
+- The above download link may be broken when the latest version of Doxygen is released. In that case, please go to the download page of [[doxygen: http: //www.doxygen.nl/index.html]] and download and install the latest "doxygen-X.X.X-setup.exe".
 
 For installation, [[Start OpenRTM-aist in 10 minutes!:/ja/doc/installation/lets_start]] page for instructions. 
 

--- a/download/01_openrtm-aist-cpp/01_openrtm-aist-cpp_1_2_2_release/01_openrtm-aist-cpp_1_2_2_release_ja.txt
+++ b/download/01_openrtm-aist-cpp/01_openrtm-aist-cpp_1_2_2_release/01_openrtm-aist-cpp_1_2_2_release_ja.txt
@@ -20,9 +20,10 @@ msiファイルは800MBのサイズがあります。ダウンロードを数分
 |Python-3.7|[[python-3.7.9-amd64.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9-amd64.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.8|[[python-3.8.5-amd64.exe:https://www.python.org/ftp/python/3.8.5/python-3.8.5-amd64.exe]]|[[python.org:https://www.python.org]]|
 |CMake |[[cmake-3.18.1-win64-x64.msi:https://github.com/Kitware/CMake/releases/download/v3.18.1/cmake-3.18.1-win64-x64.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.19-setup.exe:http://doxygen.nl/files/doxygen-1.8.19-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 -&color(red){※Pythonは、"3.8"、"3.7"、"3.6"のいずれかのバージョンをインストールしてください。};
+-Doxygenは最新版がリリースされると上記のダウンロードリンクが切れることがあります。その際は[[doxygen:http://www.doxygen.nl/index.html]]のダウンロードページに移動し、最新の "doxygen-X.X.X-setup.exe" をダウンロード・インストールしてください。
 //-&color(red){※古いrtshellは事前に削除しておいてください。ただし、OpenRTM-aist 1.1.2版をmsiファイルを用いてインストールしている場合は対応不要です。};
 
 **** 32bit用
@@ -33,11 +34,11 @@ msiファイルは800MBのサイズがあります。ダウンロードを数分
 |Python-3.7|[[python-3.7.9.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.8|[[python-3.8.5.exe:https://www.python.org/ftp/python/3.8.5/python-3.8.5.exe]]|[[python.org:https://www.python.org]]|
 |CMake|[[cmake-3.18.1-win32-x86.msi:https://github.com/Kitware/CMake/releases/download/v3.18.1/cmake-3.18.1-win32-x86.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.19-setup.exe:http://doxygen.nl/files/doxygen-1.8.19-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 -&color(red){※Pythonは、"3.8"、"3.7"、"3.6"のいずれかのバージョンをインストールしてください。};
 //-&color(red){※古いrtshellは事前に削除しておいてください。ただし、OpenRTM-aist 1.1.2版をmsiファイルを用いてインストールしている場合は対応不要です。};
-
+-Doxygenは最新版がリリースされると上記のダウンロードリンクが切れることがあります。その際は[[doxygen:http://www.doxygen.nl/index.html]]のダウンロードページに移動し、最新の "doxygen-X.X.X-setup.exe" をダウンロード・インストールしてください。
 
 
 インストールについては、[[OpenRTM-aistを10分で始めよう！:/ja/doc/installation/lets_start]]のページで手順を紹介しています。&br;

--- a/download/01_openrtm-aist-cpp/02_openrtm-aist-cpp_1_2_1_release/02_openrtm-aist-cpp_1_2_1_release_en.txt
+++ b/download/01_openrtm-aist-cpp/02_openrtm-aist-cpp_1_2_1_release/02_openrtm-aist-cpp_1_2_1_release_en.txt
@@ -17,10 +17,12 @@ The msi file is over 900MB in size. Use a high-speed line (50Mbps or more) to do
 | Python-3.6 | [[python-3.6.8-amd64.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8-amd64.exe]] | [[python .org:https://www.python.org]] |
 | Python-3.7 | [[python-3.7.5-amd64.exe:https://www.python.org/ftp/python/3.7.5/python-3.7.5-amd64.exe]] | [[python .org:https://www.python.org]] |
 | CMake | [[cmake-3.15.5-win64-x64.msi:https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-win64-x64.msi]] | [[cmake:https://cmake.org/]] |
-| Doxygen | [[doxygen-1.8.16-setup.exe:http://doxygen.nl/files/doxygen-1.8.16-setup.exe]] | [[doxygen:http://www.doxygen.nl/index.html]] |
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]]  | [[doxygen:http://www.doxygen.nl/index.html]] |
 
 - &color(red){* Install Python version "3.7", "3.6", or "2.7". };
 //- &color (red){* Please delete the old rtshell beforehand. However, if the OpenRTM-aist 1.1.2 version is installed using the msi file, no action is required. };
+- The above download link may be broken when the latest version of Doxygen is released. In that case, please go to the download page of [[doxygen: http: //www.doxygen.nl/index.html]] and download and install the latest "doxygen-X.X.X-setup.exe".
+
 
 **** For 32bit
 |LEFT:300|LEFT|LEFT:120|c
@@ -29,9 +31,12 @@ The msi file is over 900MB in size. Use a high-speed line (50Mbps or more) to do
 |Python-3.6|[[python-3.6.8.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.7|[[python-3.7.5.exe:https://www.python.org/ftp/python/3.7.5/python-3.7.5.exe]]|[[python.org:https://www.python.org]]|
 |CMake|[[cmake-3.15.5-win32-x86.msi:https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-win32-x86.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.16-setup.exe:http://doxygen.nl/files/doxygen-1.8.16-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 - &color(red){※Please install one of the version of Python "3.7", "3.6" or "2.7".};
+- The above download link may be broken when the latest version of Doxygen is released. In that case, please go to the download page of [[doxygen: http: //www.doxygen.nl/index.html]] and download and install the latest "doxygen-X.X.X-setup.exe".
+
+
 ***** Confirm installation
 It is recommended that you confirm that you can create a Visual C ++ project before the workshop.
 

--- a/download/01_openrtm-aist-cpp/02_openrtm-aist-cpp_1_2_1_release/02_openrtm-aist-cpp_1_2_1_release_ja.txt
+++ b/download/01_openrtm-aist-cpp/02_openrtm-aist-cpp_1_2_1_release/02_openrtm-aist-cpp_1_2_1_release_ja.txt
@@ -19,10 +19,11 @@ msiファイルは900MB以上のサイズがあります。ダウンロードを
 |Python-3.6|[[python-3.6.8-amd64.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8-amd64.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.7|[[python-3.7.5-amd64.exe:https://www.python.org/ftp/python/3.7.5/python-3.7.5-amd64.exe]]|[[python.org:https://www.python.org]]|
 |CMake |[[cmake-3.15.5-win64-x64.msi:https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-win64-x64.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.16-setup.exe:http://doxygen.nl/files/doxygen-1.8.16-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]]  |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 -&color(red){※Pythonは、"3.7"、"3.6"、"2.7"のいずれかのバージョンをインストールしてください。};
 //-&color(red){※古いrtshellは事前に削除しておいてください。ただし、OpenRTM-aist 1.1.2版をmsiファイルを用いてインストールしている場合は対応不要です。};
+-Doxygenは最新版がリリースされると上記のダウンロードリンクが切れることがあります。その際は[[doxygen:http://www.doxygen.nl/index.html]]のダウンロードページに移動し、最新の "doxygen-X.X.X-setup.exe" をダウンロード・インストールしてください。
 
 **** 32bit用
 
@@ -32,11 +33,11 @@ msiファイルは900MB以上のサイズがあります。ダウンロードを
 |Python-3.6|[[python-3.6.8.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.7|[[python-3.7.5.exe:https://www.python.org/ftp/python/3.7.5/python-3.7.5.exe]]|[[python.org:https://www.python.org]]|
 |CMake|[[cmake-3.15.5-win32-x86.msi:https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-win32-x86.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.16-setup.exe:http://doxygen.nl/files/doxygen-1.8.16-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 -&color(red){※Pythonは、"3.7"、"3.6"、"2.7"のいずれかのバージョンをインストールしてください。};
 //-&color(red){※古いrtshellは事前に削除しておいてください。ただし、OpenRTM-aist 1.1.2版をmsiファイルを用いてインストールしている場合は対応不要です。};
-
+-Doxygenは最新版がリリースされると上記のダウンロードリンクが切れることがあります。その際は[[doxygen:http://www.doxygen.nl/index.html]]のダウンロードページに移動し、最新の "doxygen-X.X.X-setup.exe" をダウンロード・インストールしてください。
 
 
 インストールについては、[[OpenRTM-aistを10分で始めよう！:/ja/node/6521]]のページで手順を紹介しています。&br;

--- a/download/01_openrtm-aist-cpp/03_openrtm-aist-cpp_1_1_2_release/03_openrtm-aist-cpp_1_1_2_en.txt
+++ b/download/01_openrtm-aist-cpp/03_openrtm-aist-cpp_1_1_2_release/03_openrtm-aist-cpp_1_1_2_en.txt
@@ -1,4 +1,4 @@
-﻿// Title: OpenRTM-aist C++ 1.1.2-RELEASE
+// Title: OpenRTM-aist C++ 1.1.2-RELEASE
 #ref(cpp_logo.png,nolink,right,around)
 #contents(4)
 
@@ -15,10 +15,12 @@
 |Python-2.7|[[python-2.7.10.msi:https://www.python.org/ftp/python/2.7.10/python-2.7.10.msi]]|[[python.org:https://www.python.org]]|
 |PyYAML|[[PyYAML-3.11.win32-py2.7.exe:http://pyyaml.org/download/pyyaml/PyYAML-3.11.win32-py2.7.exe]]|[[pyyaml.org:http://pyyaml.org/]]|
 |CMake|[[cmake-3.5.2-win32-x86.msi:https://cmake.org/files/v3.5/cmake-3.5.2-win32-x86.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.11-setup.exe:http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.11-setup.exe]] |[[doxygen:http://www.stack.nl/~dimitri/doxygen/]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:https://www.doxygen.nl/]]|
 
 -&color(red){* Currently Python 2.7.10 is recommended. 2.7.11 might need to set PYTHONPATH environment variables.};
 -&color(red){* Old rtshell must be removed before installing rtshell from this installer.};
+- The above download link may be broken when the latest version of Doxygen is released. In that case, please go to the download page of [[doxygen: http: //www.doxygen.nl/index.html]] and download and install the latest "doxygen-X.X.X-setup.exe".
+
 
 **** For 64bit
 
@@ -28,10 +30,12 @@
 |Python-2.7|[[python-2.7.10.amd64.msi:https://www.python.org/ftp/python/2.7.10/python-2.7.10.amd64.msi]]|[[python.org:https://www.python.org]]|
 |PyYAML |[[PyYAML-3.11.win-amd64-py2.7.exe:http://pyyaml.org/download/pyyaml/PyYAML-3.11.win-amd64-py2.7.exe]]|[[pyyaml.org:http://pyyaml.org/]]|
 |CMake |[[cmake-3.5.2-win32-x86.msi:https://cmake.org/files/v3.5/cmake-3.5.2-win32-x86.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.11-setup.exe:http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.11-setup.exe]] |[[doxygen:http://www.stack.nl/~dimitri/doxygen/]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:https://www.doxygen.nl/]]|
 
 -&color(red){* Currently Python 2.7.10 is recommended. 2.7.11 might need to set PYTHONPATH environment variables.};
 -&color(red){* Old rtshell must be removed before installing rtshell from this installer.};
+- The above download link may be broken when the latest version of Doxygen is released. In that case, please go to the download page of [[doxygen: http: //www.doxygen.nl/index.html]] and download and install the latest "doxygen-X.X.X-setup.exe".
+
 
 // インストールについては、[[OpenRTM-aistを10分で始めよう！:http://openrtm.org/openrtm/ja/node/6026]] のページで手順を紹介しています。&br;
 

--- a/download/01_openrtm-aist-cpp/03_openrtm-aist-cpp_1_1_2_release/03_openrtm-aist-cpp_1_1_2_ja.txt
+++ b/download/01_openrtm-aist-cpp/03_openrtm-aist-cpp_1_1_2_release/03_openrtm-aist-cpp_1_1_2_ja.txt
@@ -1,4 +1,4 @@
-﻿// Title: OpenRTM-aist C++ 1.1.2-RELEASE
+// Title: OpenRTM-aist C++ 1.1.2-RELEASE
 #ref(cpp_logo.png,nolink,right,around)
 #contents(4)
 
@@ -15,10 +15,11 @@
 |Python-2.7|[[python-2.7.10.msi:https://www.python.org/ftp/python/2.7.10/python-2.7.10.msi]]|[[python.org:https://www.python.org]]|
 |PyYAML|[[PyYAML-3.11.win32-py2.7.exe:http://pyyaml.org/download/pyyaml/PyYAML-3.11.win32-py2.7.exe]]|[[pyyaml.org:http://pyyaml.org/]]|
 |CMake|[[cmake-3.5.2-win32-x86.msi:https://cmake.org/files/v3.5/cmake-3.5.2-win32-x86.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.11-setup.exe:http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.11-setup.exe]] |[[doxygen:http://www.stack.nl/~dimitri/doxygen/]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://doxygen.nl/]]|
 
 -&color(red){※ Python 2.7.10 推奨。2.7.11 は PYTHONPATH 等環境変数の設定が必要な場合があります。};
 -&color(red){※ 古い rtshell は事前に削除しておいてください。};
+-Doxygenは最新版がリリースされると上記のダウンロードリンクが切れることがあります。その際は[[doxygen:http://www.doxygen.nl/index.html]]のダウンロードページに移動し、最新の "doxygen-X.X.X-setup.exe" をダウンロード・インストールしてください。
 
 **** 64bit用
 
@@ -28,10 +29,11 @@
 |Python-2.7|[[python-2.7.10.amd64.msi:https://www.python.org/ftp/python/2.7.10/python-2.7.10.amd64.msi]]|[[python.org:https://www.python.org]]|
 |PyYAML |[[PyYAML-3.11.win-amd64-py2.7.exe:http://pyyaml.org/download/pyyaml/PyYAML-3.11.win-amd64-py2.7.exe]]|[[pyyaml.org:http://pyyaml.org/]]|
 |CMake |[[cmake-3.5.2-win32-x86.msi:https://cmake.org/files/v3.5/cmake-3.5.2-win32-x86.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.11-setup.exe:http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.11-setup.exe]] |[[doxygen:http://www.stack.nl/~dimitri/doxygen/]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://doxygen.nl/]]|
 
 -&color(red){※ Python 2.7.10 推奨。2.7.11は PYTHONPATH 等環境変数の設定が必要な場合があります。};
 -&color(red){※ 古い rtshell は事前に削除しておいてください。};
+-Doxygenは最新版がリリースされると上記のダウンロードリンクが切れることがあります。その際は[[doxygen:http://www.doxygen.nl/index.html]]のダウンロードページに移動し、最新の "doxygen-X.X.X-setup.exe" をダウンロード・インストールしてください。
 
 インストールについては、[[OpenRTM-aistを10分で始めよう！:http://openrtm.org/openrtm/ja/node/6026]] のページで手順を紹介しています。&br;
 

--- a/download/02_openrtm-aist-java/01_openrtm-aist-java_1_2_2_release/01_openrtm-aist-java_1_2_2_release_en.txt
+++ b/download/02_openrtm-aist-java/01_openrtm-aist-java_1_2_2_release/01_openrtm-aist-java_1_2_2_release_en.txt
@@ -19,10 +19,12 @@ The msi file is 800MB in size. Use a high-speed line (50Mbps or more) to downloa
 |Python-3.7|[[python-3.7.9-amd64.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9-amd64.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.8|[[python-3.8.5-amd64.exe:https://www.python.org/ftp/python/3.8.5/python-3.8.5-amd64.exe]]|[[python.org:https://www.python.org]]|
 |CMake |[[cmake-3.18.1-win64-x64.msi:https://github.com/Kitware/CMake/releases/download/v3.18.1/cmake-3.18.1-win64-x64.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.19-setup.exe:http://doxygen.nl/files/doxygen-1.8.19-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+
 
 - &color(red){* Install Python version "3.8", "3.7", or "3.6". };
-//- &color(red){* Please delete the old rtshell beforehand. However, if the OpenRTM-aist 1.1.2 version is installed using the msi file, no action is required. };
+//- &color (red){* Please delete the old rtshell beforehand. However, if the OpenRTM-aist 1.1.2 version is installed using the msi file, no action is required. };
+- The above download link may be broken when the latest version of Doxygen is released. In that case, please go to the download page of [[doxygen:http://www.doxygen.nl/index.html]] and download and install the latest "doxygen-X.X.X-setup.exe".
 
 **** For 32bit
 
@@ -32,10 +34,12 @@ The msi file is 800MB in size. Use a high-speed line (50Mbps or more) to downloa
 |Python-3.7|[[python-3.7.9.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.8|[[python-3.8.5.exe:https://www.python.org/ftp/python/3.8.5/python-3.8.5.exe]]|[[python.org:https://www.python.org]]|
 |CMake|[[cmake-3.18.1-win32-x86.msi:https://github.com/Kitware/CMake/releases/download/v3.18.1/cmake-3.18.1-win32-x86.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.19-setup.exe:http://doxygen.nl/files/doxygen-1.8.19-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+
 
 - &color(red){* Install Python version "3.8", "3.7", or "3.6". };
-//- &color(red){* Please delete the old rtshell beforehand. However, if the OpenRTM-aist 1.1.2 version is installed using the msi file, no action is required. };
+//- &color (red){* Please delete the old rtshell beforehand. However, if the OpenRTM-aist 1.1.2 version is installed using the msi file, no action is required. };
+- The above download link may be broken when the latest version of Doxygen is released. In that case, please go to the download page of [[doxygen:http://www.doxygen.nl/index.html]] and download and install the latest "doxygen-X.X.X-setup.exe".
 
 
 For installation, [[Start OpenRTM-aist in 10 minutes!:/ja/doc/installation/lets_start]] page for instructions. &br;

--- a/download/02_openrtm-aist-java/01_openrtm-aist-java_1_2_2_release/01_openrtm-aist-java_1_2_2_release_ja.txt
+++ b/download/02_openrtm-aist-java/01_openrtm-aist-java_1_2_2_release/01_openrtm-aist-java_1_2_2_release_ja.txt
@@ -18,10 +18,11 @@ msiファイルは800MBのサイズがあります。ダウンロードを数分
 |Python-3.7|[[python-3.7.9-amd64.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9-amd64.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.8|[[python-3.8.5-amd64.exe:https://www.python.org/ftp/python/3.8.5/python-3.8.5-amd64.exe]]|[[python.org:https://www.python.org]]|
 |CMake |[[cmake-3.18.1-win64-x64.msi:https://github.com/Kitware/CMake/releases/download/v3.18.1/cmake-3.18.1-win64-x64.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.19-setup.exe:http://doxygen.nl/files/doxygen-1.8.19-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]]  |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 -&color(red){※Pythonは、"3.8"、"3.7"、"3.6"のいずれかのバージョンをインストールしてください。};
 //-&color(red){※古いrtshellは事前に削除しておいてください。ただし、OpenRTM-aist 1.1.2版をmsiファイルを用いてインストールしている場合は対応不要です。};
+-Doxygenは最新版がリリースされると上記のダウンロードリンクが切れることがあります。その際は[[doxygen:http://www.doxygen.nl/index.html]]のダウンロードページに移動し、最新の "doxygen-X.X.X-setup.exe" をダウンロード・インストールしてください。
 
 **** 32bit用
 
@@ -31,11 +32,11 @@ msiファイルは800MBのサイズがあります。ダウンロードを数分
 |Python-3.7|[[python-3.7.9.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.8|[[python-3.8.5.exe:https://www.python.org/ftp/python/3.8.5/python-3.8.5.exe]]|[[python.org:https://www.python.org]]|
 |CMake|[[cmake-3.18.1-win32-x86.msi:https://github.com/Kitware/CMake/releases/download/v3.18.1/cmake-3.18.1-win32-x86.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.19-setup.exe:http://doxygen.nl/files/doxygen-1.8.19-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]]  |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 -&color(red){※Pythonは、"3.8"、"3.7"、"3.6"のいずれかのバージョンをインストールしてください。};
 //-&color(red){※古いrtshellは事前に削除しておいてください。ただし、OpenRTM-aist 1.1.2版をmsiファイルを用いてインストールしている場合は対応不要です。};
-
+-Doxygenは最新版がリリースされると上記のダウンロードリンクが切れることがあります。その際は[[doxygen:http://www.doxygen.nl/index.html]]のダウンロードページに移動し、最新の "doxygen-X.X.X-setup.exe" をダウンロード・インストールしてください。
 
 インストールについては、[[OpenRTM-aistを10分で始めよう！:/ja/doc/installation/lets_start]]のページで手順を紹介しています。&br;
 

--- a/download/02_openrtm-aist-java/02_openrtm-aist-java_1_2_1_release/02_openrtm-aist-java_1_2_1_release_en.txt
+++ b/download/02_openrtm-aist-java/02_openrtm-aist-java_1_2_1_release/02_openrtm-aist-java_1_2_1_release_en.txt
@@ -18,10 +18,11 @@ The msi file is over 900MB in size. Use a high-speed line (50Mbps or more) to do
 | Python-3.6 | [[python-3.6.8-amd64.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8-amd64.exe]] | [[python .org:https://www.python.org]] |
 | Python-3.7 | [[python-3.7.5-amd64.exe:https://www.python.org/ftp/python/3.7.5/python-3.7.5-amd64.exe]] | [[python .org:https://www.python.org]] |
 | CMake | [[cmake-3.15.5-win64-x64.msi:https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-win64-x64.msi]] | [[cmake:https://cmake.org/]] |
-| Doxygen | [[doxygen-1.8.16-setup.exe:http://doxygen.nl/files/doxygen-1.8.16-setup.exe]] | [[doxygen:http://www.doxygen.nl/index.html]] |
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 - &color(red){* Install Python version "3.7", "3.6", or "2.7". };
 //- &color(red){* Please delete the old rtshell beforehand. However, if the OpenRTM-aist 1.1.2 version is installed using the msi file, no action is required. };
+- The above download link may be broken when the latest version of Doxygen is released. In that case, please go to the download page of [[doxygen:http://www.doxygen.nl/index.html]] and download and install the latest "doxygen-X.X.X-setup.exe".
 
 **** For 32bit
 

--- a/download/02_openrtm-aist-java/02_openrtm-aist-java_1_2_1_release/02_openrtm-aist-java_1_2_1_release_ja.txt
+++ b/download/02_openrtm-aist-java/02_openrtm-aist-java_1_2_1_release/02_openrtm-aist-java_1_2_1_release_ja.txt
@@ -1,4 +1,4 @@
-﻿// Title: OpenRTM-aist-Java-1.2.1-RELEASE
+// Title: OpenRTM-aist-Java-1.2.1-RELEASE
 #ref(java_logo.png,right,nolink,around)
 #contents(4)
 
@@ -18,10 +18,11 @@ msiファイルは900MB以上のサイズがあります。ダウンロードを
 |Python-3.6|[[python-3.6.8-amd64.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8-amd64.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.7|[[python-3.7.5-amd64.exe:https://www.python.org/ftp/python/3.7.5/python-3.7.5-amd64.exe]]|[[python.org:https://www.python.org]]|
 |CMake |[[cmake-3.15.5-win64-x64.msi:https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-win64-x64.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.16-setup.exe:http://doxygen.nl/files/doxygen-1.8.16-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]]  |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 -&color(red){※Pythonは、"3.7"、"3.6"、"2.7"のいずれかのバージョンをインストールしてください。};
 //-&color(red){※古いrtshellは事前に削除しておいてください。ただし、OpenRTM-aist 1.1.2版をmsiファイルを用いてインストールしている場合は対応不要です。};
+-Doxygenは最新版がリリースされると上記のダウンロードリンクが切れることがあります。その際は[[doxygen:http://www.doxygen.nl/index.html]]のダウンロードページに移動し、最新の "doxygen-X.X.X-setup.exe" をダウンロード・インストールしてください。
 
 **** 32bit用
 
@@ -31,11 +32,11 @@ msiファイルは900MB以上のサイズがあります。ダウンロードを
 |Python-3.6|[[python-3.6.8.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.7|[[python-3.7.5.exe:https://www.python.org/ftp/python/3.7.5/python-3.7.5.exe]]|[[python.org:https://www.python.org]]|
 |CMake|[[cmake-3.15.5-win32-x86.msi:https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-win32-x86.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.16-setup.exe:http://doxygen.nl/files/doxygen-1.8.16-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]]  |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 -&color(red){※Pythonは、"3.7"、"3.6"、"2.7"のいずれかのバージョンをインストールしてください。};
 //-&color(red){※古いrtshellは事前に削除しておいてください。ただし、OpenRTM-aist 1.1.2版をmsiファイルを用いてインストールしている場合は対応不要です。};
-
+-Doxygenは最新版がリリースされると上記のダウンロードリンクが切れることがあります。その際は[[doxygen:http://www.doxygen.nl/index.html]]のダウンロードページに移動し、最新の "doxygen-X.X.X-setup.exe" をダウンロード・インストールしてください。
 
 インストールについては、[[OpenRTM-aistを10分で始めよう！:/ja/node/6521]]のページで手順を紹介しています。&br;
 

--- a/download/03_openrtm-aist-python/01_openrtm-aist-python_1_2_2_release/01_openrtm-aist-python_1_2_2_release_en.txt
+++ b/download/03_openrtm-aist-python/01_openrtm-aist-python_1_2_2_release/01_openrtm-aist-python_1_2_2_release_en.txt
@@ -19,9 +19,11 @@ The msi file is 800MB in size. Use a high-speed line (50Mbps or more) to downloa
 |Python-3.7|[[python-3.7.9-amd64.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9-amd64.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.8|[[python-3.8.5-amd64.exe:https://www.python.org/ftp/python/3.8.5/python-3.8.5-amd64.exe]]|[[python.org:https://www.python.org]]|
 |CMake |[[cmake-3.18.1-win64-x64.msi:https://github.com/Kitware/CMake/releases/download/v3.18.1/cmake-3.18.1-win64-x64.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.19-setup.exe:http://doxygen.nl/files/doxygen-1.8.19-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 -&color(red){* Install Python version "3.8", "3.7", or "3.6". };
+- The above download link may be broken when the latest version of Doxygen is released. In that case, please go to the download page of [[doxygen: http: //www.doxygen.nl/index.html]] and download and install the latest "doxygen-X.X.X-setup.exe".
+
 
 **** For 32bit
 
@@ -31,9 +33,10 @@ The msi file is 800MB in size. Use a high-speed line (50Mbps or more) to downloa
 |Python-3.7|[[python-3.7.9.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.8|[[python-3.8.5.exe:https://www.python.org/ftp/python/3.8.5/python-3.8.5.exe]]|[[python.org:https://www.python.org]]|
 |CMake|[[cmake-3.18.1-win32-x86.msi:https://github.com/Kitware/CMake/releases/download/v3.18.1/cmake-3.18.1-win32-x86.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.19-setup.exe:http://doxygen.nl/files/doxygen-1.8.19-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 -&color(red){* Install Python version "3.8", "3.7" or "3.6". };
+- The above download link may be broken when the latest version of Doxygen is released. In that case, please go to the download page of [[doxygen: http: //www.doxygen.nl/index.html]] and download and install the latest "doxygen-X.X.X-setup.exe".
 
 
 For installation, [[Start OpenRTM-aist in 10 minutes!:/ja/doc/installation/lets_start]] page for instructions. 

--- a/download/03_openrtm-aist-python/01_openrtm-aist-python_1_2_2_release/01_openrtm-aist-python_1_2_2_release_ja.txt
+++ b/download/03_openrtm-aist-python/01_openrtm-aist-python_1_2_2_release/01_openrtm-aist-python_1_2_2_release_ja.txt
@@ -20,10 +20,11 @@ msiファイルは800MBのサイズがあります。ダウンロードを数分
 |Python-3.7|[[python-3.7.9-amd64.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9-amd64.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.8|[[python-3.8.5-amd64.exe:https://www.python.org/ftp/python/3.8.5/python-3.8.5-amd64.exe]]|[[python.org:https://www.python.org]]|
 |CMake |[[cmake-3.18.1-win64-x64.msi:https://github.com/Kitware/CMake/releases/download/v3.18.1/cmake-3.18.1-win64-x64.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.19-setup.exe:http://doxygen.nl/files/doxygen-1.8.19-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]]  |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 -&color(red){※Pythonは、"3.8"、"3.7"、"3.6"のいずれかのバージョンをインストールしてください。};
 //-&color(red){※古いrtshellは事前に削除しておいてください。ただし、OpenRTM-aist 1.1.2版をmsiファイルを用いてインストールしている場合は対応不要です。};
+-Doxygenは最新版がリリースされると上記のダウンロードリンクが切れることがあります。その際は[[doxygen:http://www.doxygen.nl/index.html]]のダウンロードページに移動し、最新の "doxygen-X.X.X-setup.exe" をダウンロード・インストールしてください。
 
 **** 32bit用
 
@@ -33,11 +34,11 @@ msiファイルは800MBのサイズがあります。ダウンロードを数分
 |Python-3.7|[[python-3.7.9.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.8|[[python-3.8.5.exe:https://www.python.org/ftp/python/3.8.5/python-3.8.5.exe]]|[[python.org:https://www.python.org]]|
 |CMake|[[cmake-3.18.1-win32-x86.msi:https://github.com/Kitware/CMake/releases/download/v3.18.1/cmake-3.18.1-win32-x86.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.19-setup.exe:http://doxygen.nl/files/doxygen-1.8.19-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]]  |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 -&color(red){※Pythonは、"3.8"、"3.7"、"3.6"のいずれかのバージョンをインストールしてください。};
 //-&color(red){※古いrtshellは事前に削除しておいてください。ただし、OpenRTM-aist 1.1.2版をmsiファイルを用いてインストールしている場合は対応不要です。};
-
+-Doxygenは最新版がリリースされると上記のダウンロードリンクが切れることがあります。その際は[[doxygen:http://www.doxygen.nl/index.html]]のダウンロードページに移動し、最新の "doxygen-X.X.X-setup.exe" をダウンロード・インストールしてください。
 
 インストールについては、[[OpenRTM-aistを10分で始めよう！:/ja/doc/installation/lets_start]]のページで手順を紹介しています。&br;
 

--- a/download/03_openrtm-aist-python/02_openrtm-aist-python_1_2_1_release/02_openrtm-aist-python_1_2_1_release_en.txt
+++ b/download/03_openrtm-aist-python/02_openrtm-aist-python_1_2_1_release/02_openrtm-aist-python_1_2_1_release_en.txt
@@ -13,27 +13,30 @@ The msi file is over 900MB in size. Use a high-speed line (50Mbps or more) to do
 
 **** For 64bit
 
-| LEFT:300 | LEFT | LEFT:120 | c
-| Installer for Windows &br; (including OpenRTM-aist, C ++, Python, &br; Java version and OpenRTP, &br; rtshell (4.2.2)) &br; (Visual Studio 2010, 2012, &br; 2013, 2015, 2017 , 2019)) | .msi]] &br; MD5: be6b346d61768435d812cc032bc7a529 | November 25, 2019 |
+//| LEFT:300 | LEFT | LEFT:120 |
+|LEFT:300|LEFT|LEFT:120|c
+| Installer for Windows &br; (including OpenRTM-aist, C ++, Python, &br; Java version and OpenRTP, &br; RTShell (4.2.2)) &br; (Visual Studio 2010, 2012, &br; 2013, 2015, 2017 , 2019)) | .msi]] &br; MD5: be6b346d61768435d812cc032bc7a529 | November 25, 2019 |
 | Python-2.7 | [[python-2.7.16.amd64.msi:https://www.python.org/ftp/python/2.7.16/python-2.7.16.amd64.msi]] | [[python.org:https://www.python.org]] |
 | Python-3.6 | [[python-3.6.8-amd64.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8-amd64.exe]] | [[python.org:https://www.python.org]] |
 | Python-3.7 | [[python-3.7.5-amd64.exe:https://www.python.org/ftp/python/3.7.5/python-3.7.5-amd64.exe]] | [[[python.org:https://www.python.org]] |
 | CMake | [[cmake-3.15.5-win64-x64.msi:https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-win64-x64.msi]] | [[cmake:https://cmake.org/]] |
-| Doxygen | [[doxygen-1.8.16-setup.exe:http://doxygen.nl/files/doxygen-1.8.16-setup.exe]] | [[doxygen:http://www.doxygen.nl/index.html]] |
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] | [[doxygen:http://www.doxygen.nl/index.html]] |
 
 -&color(red){* Install Python version "3.7", "3.6", or "2.7". };
+- The above download link may be broken when the latest version of Doxygen is released. In that case, please go to the download page of [[doxygen: http: //www.doxygen.nl/index.html]] and download and install the latest "doxygen-X.X.X-setup.exe".
 
 **** For 32bit
 
-| LEFT:300 | LEFT | LEFT:120 |c
-| Windows installer &br; (including OpenRTM-aist, C ++, Python, &br; Java version and OpenRTP, &br; rtshell (4.2.2)) &br; (Visual Studio 2010, 2012, &br; 2013, 2015, 2017, 2019 Common) | [[OpenRTM-aist-1.2.1-RELEASE_x86.msi:https://github.com/OpenRTM/OpenRTM-aist/releases/download/v1.2.1/OpenRTM-aist-1.2.1-RELEASE_x86. msi]] &br; MD5: a9186d409cafc039432a0e1c6e7e02ef | November 25, 2019 |
+| LEFT:300 | LEFT | LEFT:120 |
+| Windows installer &br; (including OpenRTM-aist, C ++, Python, &br; Java version and OpenRTP, &br; RTShell (4.2.2)) &br; (Visual Studio 2010, 2012, &br; 2013, 2015, 2017, 2019 Common) | [[OpenRTM-aist-1.2.1-RELEASE_x86.msi:https://github.com/OpenRTM/OpenRTM-aist/releases/download/v1.2.1/OpenRTM-aist-1.2.1-RELEASE_x86. msi]] &br; MD5: a9186d409cafc039432a0e1c6e7e02ef | November 25, 2019 |
 | Python-2.7 | [[python-2.7.16.msi:https://www.python.org/ftp/python/2.7.16/python-2.7.16.msi]] | [[python.org:https://www.python.org]] |
 | Python-3.6 | [[python-3.6.8.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8.exe]] | [[python.org:https://www.python.org]] |
 | Python-3.7 | [[python-3.7.5.exe:https://www.python.org/ftp/python/3.7.5/python-3.7.5.exe]] | [[python.org:https://www.python.org]] |
 | CMake | [[cmake-3.15.5-win32-x86.msi:https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-win32-x86.msi]] | [[cmake:https://cmake.org/]] |
-| Doxygen | [[doxygen-1.8.16-setup.exe:http://doxygen.nl/files/doxygen-1.8.16-setup.exe]] | [[doxygen:http://www.doxygen.nl/index.html]] |
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]]  | [[doxygen:http://www.doxygen.nl/index.html]] |
 
 -&color(red){* Install Python version "3.7", "3.6", or "2.7". };
+- The above download link may be broken when the latest version of Doxygen is released. In that case, please go to the download page of [[doxygen: http: //www.doxygen.nl/index.html]] and download and install the latest "doxygen-X.X.X-setup.exe".
 
 
 For installation, [[Start OpenRTM-aist in 10 minutes!:/ja/node/6521]] page for instructions. 

--- a/download/03_openrtm-aist-python/02_openrtm-aist-python_1_2_1_release/02_openrtm-aist-python_1_2_1_release_ja.txt
+++ b/download/03_openrtm-aist-python/02_openrtm-aist-python_1_2_1_release/02_openrtm-aist-python_1_2_1_release_ja.txt
@@ -1,4 +1,4 @@
-﻿// Title: OpenRTM-aist-Python 1.2.1-RELEASE
+// Title: OpenRTM-aist-Python 1.2.1-RELEASE
 #ref(cpp_logo.png,nolink,right,around)
 #contents(4)
 
@@ -19,10 +19,11 @@ msiファイルは900MB以上のサイズがあります。ダウンロードを
 |Python-3.6|[[python-3.6.8-amd64.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8-amd64.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.7|[[python-3.7.5-amd64.exe:https://www.python.org/ftp/python/3.7.5/python-3.7.5-amd64.exe]]|[[python.org:https://www.python.org]]|
 |CMake |[[cmake-3.15.5-win64-x64.msi:https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-win64-x64.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.16-setup.exe:http://doxygen.nl/files/doxygen-1.8.16-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]]  |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 -&color(red){※Pythonは、"3.7"、"3.6"、"2.7"のいずれかのバージョンをインストールしてください。};
 //-&color(red){※古いrtshellは事前に削除しておいてください。ただし、OpenRTM-aist 1.1.2版をmsiファイルを用いてインストールしている場合は対応不要です。};
+-Doxygenは最新版がリリースされると上記のダウンロードリンクが切れることがあります。その際は[[doxygen:http://www.doxygen.nl/index.html]]のダウンロードページに移動し、最新の "doxygen-X.X.X-setup.exe" をダウンロード・インストールしてください。
 
 **** 32bit用
 
@@ -32,10 +33,11 @@ msiファイルは900MB以上のサイズがあります。ダウンロードを
 |Python-3.6|[[python-3.6.8.exe:https://www.python.org/ftp/python/3.6.8/python-3.6.8.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.7|[[python-3.7.5.exe:https://www.python.org/ftp/python/3.7.5/python-3.7.5.exe]]|[[python.org:https://www.python.org]]|
 |CMake|[[cmake-3.15.5-win32-x86.msi:https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-win32-x86.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.16-setup.exe:http://doxygen.nl/files/doxygen-1.8.16-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 -&color(red){※Pythonは、"3.7"、"3.6"、"2.7"のいずれかのバージョンをインストールしてください。};
 //-&color(red){※古いrtshellは事前に削除しておいてください。ただし、OpenRTM-aist 1.1.2版をmsiファイルを用いてインストールしている場合は対応不要です。};
+-Doxygenは最新版がリリースされると上記のダウンロードリンクが切れることがあります。その際は[[doxygen:http://www.doxygen.nl/index.html]]のダウンロードページに移動し、最新の "doxygen-X.X.X-setup.exe" をダウンロード・インストールしてください。
 
 
 インストールについては、[[OpenRTM-aistを10分で始めよう！:/ja/node/6521]]のページで手順を紹介しています。&br;

--- a/download/04_tools/01_openrtp_1_2_2/01_openrtp_1_2_2_en.txt
+++ b/download/04_tools/01_openrtp_1_2_2/01_openrtp_1_2_2_en.txt
@@ -20,9 +20,12 @@ The msi file is 800MB in size. Use a high-speed line (50Mbps or more) to downloa
 |Python-3.7|[[python-3.7.9-amd64.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9-amd64.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.8|[[python-3.8.5-amd64.exe:https://www.python.org/ftp/python/3.8.5/python-3.8.5-amd64.exe]]|[[python.org:https://www.python.org]]|
 |CMake |[[cmake-3.18.1-win64-x64.msi:https://github.com/Kitware/CMake/releases/download/v3.18.1/cmake-3.18.1-win64-x64.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.19-setup.exe:http://doxygen.nl/files/doxygen-1.8.19-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+
 
 - &color(red){* Install Python version "3.8", "3.7", or "3.6". };
+//- &color (red){* Please delete the old rtshell beforehand. However, if the OpenRTM-aist 1.1.2 version is installed using the msi file, no action is required. };
+- The above download link may be broken when the latest version of Doxygen is released. In that case, please go to the download page of [[doxygen:http://www.doxygen.nl/index.html]] and download and install the latest "doxygen-X.X.X-setup.exe".
 
 **** For 32bit
 
@@ -32,10 +35,12 @@ The msi file is 800MB in size. Use a high-speed line (50Mbps or more) to downloa
 |Python-3.7|[[python-3.7.9.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.8|[[python-3.8.5.exe:https://www.python.org/ftp/python/3.8.5/python-3.8.5.exe]]|[[python.org:https://www.python.org]]|
 |CMake|[[cmake-3.18.1-win32-x86.msi:https://github.com/Kitware/CMake/releases/download/v3.18.1/cmake-3.18.1-win32-x86.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.19-setup.exe:http://doxygen.nl/files/doxygen-1.8.19-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+
 
 - &color(red){* Install Python version "3.8", "3.7", or "3.6". };
-
+//- &color (red){* Please delete the old rtshell beforehand. However, if the OpenRTM-aist 1.1.2 version is installed using the msi file, no action is required. };
+- The above download link may be broken when the latest version of Doxygen is released. In that case, please go to the download page of [[doxygen:http://www.doxygen.nl/index.html]] and download and install the latest "doxygen-X.X.X-setup.exe".
 
 For installation, [[Start OpenRTM-aist in 10 minutes!:/ja/doc/installation/lets_start]] page for instructions. &br;
 

--- a/download/04_tools/01_openrtp_1_2_2/01_openrtp_1_2_2_ja.txt
+++ b/download/04_tools/01_openrtp_1_2_2/01_openrtp_1_2_2_ja.txt
@@ -19,10 +19,10 @@ msiファイルは800MBのサイズがあります。ダウンロードを数分
 |Python-3.7|[[python-3.7.9-amd64.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9-amd64.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.8|[[python-3.8.5-amd64.exe:https://www.python.org/ftp/python/3.8.5/python-3.8.5-amd64.exe]]|[[python.org:https://www.python.org]]|
 |CMake |[[cmake-3.18.1-win64-x64.msi:https://github.com/Kitware/CMake/releases/download/v3.18.1/cmake-3.18.1-win64-x64.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.19-setup.exe:http://doxygen.nl/files/doxygen-1.8.19-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 -&color(red){※Pythonは、"3.8"、"3.7"、"3.6"のいずれかのバージョンをインストールしてください。};
-//-&color(red){※古いrtshellは事前に削除しておいてください。ただし、OpenRTM-aist 1.1.2版をmsiを用いてでインストールしている場合は対応不要です。};
+-Doxygenは最新版がリリースされると上記のダウンロードリンクが切れることがあります。その際は[[doxygen:http://www.doxygen.nl/index.html]]のダウンロードページに移動し、最新の "doxygen-X.X.X-setup.exe" をダウンロード・インストールしてください。
 
 **** 32bit用
 
@@ -32,11 +32,10 @@ msiファイルは800MBのサイズがあります。ダウンロードを数分
 |Python-3.7|[[python-3.7.9.exe:https://www.python.org/ftp/python/3.7.9/python-3.7.9.exe]]|[[python.org:https://www.python.org]]|
 |Python-3.8|[[python-3.8.5.exe:https://www.python.org/ftp/python/3.8.5/python-3.8.5.exe]]|[[python.org:https://www.python.org]]|
 |CMake|[[cmake-3.18.1-win32-x86.msi:https://github.com/Kitware/CMake/releases/download/v3.18.1/cmake-3.18.1-win32-x86.msi]] |[[cmake:https://cmake.org/]]|
-|Doxygen|[[doxygen-1.8.19-setup.exe:http://doxygen.nl/files/doxygen-1.8.19-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
+|Doxygen|[[doxygen-1.9.2-setup.exe:https://www.doxygen.nl/files/doxygen-1.9.2-setup.exe]] |[[doxygen:http://www.doxygen.nl/index.html]]|
 
 -&color(red){※Pythonは、"3.8"、"3.7"、"3.6"のいずれかのバージョンをインストールしてください。};
-//-&color(red){※古いrtshellは事前に削除しておいてください。ただし、OpenRTM-aist 1.1.2版をmsiを用いてインストールしている場合は対応不要です。};
-
+-Doxygenは最新版がリリースされると上記のダウンロードリンクが切れることがあります。その際は[[doxygen:http://www.doxygen.nl/index.html]]のダウンロードページに移動し、最新の "doxygen-X.X.X-setup.exe" をダウンロード・インストールしてください。
 
 インストールについては、[[OpenRTM-aistを10分で始めよう！:/ja/doc/installation/lets_start]]のページで手順を紹介しています。&br;
 


### PR DESCRIPTION
link to #308 
上記のissueに伴う更新（リンク切れの修正）を行いました。

 - https://openrtm.org/openrtm/ja/download/openrtm-aist-cpp/openrtm-aist-cpp_1_2_2_release
   - ->  ./download/01_openrtm-aist-cpp/01_openrtm-aist-cpp_1_2_2_release/01_openrtm-aist-cpp_ja.txt
 - https://openrtm.org/openrtm/en/download/openrtm-aist-cpp/openrtm-aist-cpp_1_2_2_release
   - ->  ./download/01_openrtm-aist-cpp/01_openrtm-aist-cpp_1_2_2_release/01_openrtm-aist-cpp_en.txt
 - https://openrtm.org/openrtm/ja/download/openrtm-aist-python/openrtm-aist-python_1_2_2_release
   - ->  ./download/03_openrtm-aist-python/01_openrtm-aist-python_1_2_2_release/01_openrtm-aist-python_1_2_2_release_ja.txt
 - https://openrtm.org/openrtm/en/download/openrtm-aist-python/openrtm-aist-python_1_2_2_release
   - -> ./download/03_openrtm-aist-python/01_openrtm-aist-python_1_2_2_release/01_openrtm-aist-python_1_2_2_release_en.txt
 - https://openrtm.org/openrtm/ja/download/openrtm-aist-java/openrtm-aist-java_1_2_2_release
   - -> ./download/02_openrtm-aist-java/01_openrtm-aist-java_1_2_2_release/01_openrtm-aist-java_1_2_2_release_ja.txt
 - https://openrtm.org/openrtm/en/download/openrtm-aist-java/openrtm-aist-java_1_2_2_release
   - -> ./download/02_openrtm-aist-java/01_openrtm-aist-java_1_2_2_release/01_openrtm-aist-java_1_2_2_release_en.txt
 - https://openrtm.org/openrtm/ja/download/tools/openrtp_1_2_2
   - -> ./download/04_tools/01_openrtp_1_2_2/01_openrtp_1_2_2_ja.txt
 - https://openrtm.org/openrtm/en/download/tools/openrtp_1_2_2
   - -> ./download/04_tools/01_openrtp_1_2_2/01_openrtp_1_2_2_en.txt


- [x] Did you check grammar?  (ex. https://www.grammarly.com/, https://www.kiji-check.com/) 
- [x] Did you check pukiwiki grammar?
- [x] Did you check Japanese-English consistency?  
